### PR TITLE
fix broken master branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
         ]
     },
     install_requires=[
-        'svreal>=0.1.9',
-        'msdsl>=0.1.6',
+        'svreal==0.1.9',
+        'msdsl==0.1.6',
         'jinja2',
         'pyvcd',
         'pyserial',


### PR DESCRIPTION
Looks like the master branch broke because setup.py used ">=" rather than "==" to specify versions of msdsl and svreal.  Probably while these packages are in development, we should use "==" because breaking changes are possible.