### PR TITLE
Minor bug fixes

### DIFF
--- a/anasymod/generators/vivado.py
+++ b/anasymod/generators/vivado.py
@@ -95,6 +95,11 @@ class VivadoTCLGenerator(CodeGenerator):
         self.set_property('verilog_define', f"{{{' '.join(define_list)}}}", fileset)
 
     def add_files(self, files, norecurse=True, fileset=None):
+        if files is None or len(files) == 0:
+            # don't generate a command because add_files does not work with
+            # an empty list of files
+            return
+
         cmd = ['add_files']
         if fileset is not None:
             cmd.extend(['-fileset', fileset])

--- a/anasymod/structures/module_emu_clks.py
+++ b/anasymod/structures/module_emu_clks.py
@@ -56,8 +56,8 @@ class ModuleEmuClks(JinjaTempl):
             self.generated_clks.writeln(f'')
             self.generated_clks.writeln(f'`ifndef SIMULATION_MODE_MSDSL')
             self.generated_clks.indent()
-            for gated_clk_sig_name in gated_clk_sig_names:
-                self.generated_clks.writeln(f'BUFG buf_i (.I(clk_unbuf_{gated_clk_sig_name}), .O(clk_{gated_clk_sig_name}));')
+            for k, gated_clk_sig_name in enumerate(gated_clk_sig_names):
+                self.generated_clks.writeln(f'BUFG buf_{k} (.I(clk_unbuf_{gated_clk_sig_name}), .O(clk_{gated_clk_sig_name}));')
             self.generated_clks.dedent()
             self.generated_clks.writeln(f'`else')
             self.generated_clks.indent()

--- a/anasymod/structures/module_top.py
+++ b/anasymod/structures/module_top.py
@@ -201,6 +201,11 @@ class ModuleTop(JinjaTempl):
         time_manager_inst.add_input(scfg.emu_clk, connection=scfg.emu_clk)
         time_manager_inst.add_input(scfg.reset_ctrl, connection=scfg.reset_ctrl)
         time_manager_inst.add_output(scfg.time_probe, scfg.time_probe)
+        if scfg.num_dt_reqs > 0:
+            # wire up the emu_dt signal if needed
+            # TODO: cleanup
+            emu_dt = DigitalSignal(name='emu_dt', abspath='', width=pcfg.cfg.dt_width, signed=True)
+            time_manager_inst.add_output(emu_dt, emu_dt)
         for dt_req_sig_name in dt_req_sig_names:
             dt_req_sig = DigitalSignal(name=f'dt_req_{dt_req_sig_name}', abspath='', width=pcfg.cfg.dt_width, signed=True)
             time_manager_inst.add_input(dt_req_sig, connection=dt_req_sig)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.1.dev2'
+version = '0.2.1'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.0'
+version = '0.2.1.dev1'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.1.dev1'
+version = '0.2.1.dev2'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\


### PR DESCRIPTION
This PR fixes a couple of small bugs encountered during testing with the DragonPHY project:
- For the Vivado TCL generator, if ``files`` is empty the output command had a syntax error.
- In the buffering of derived clocks, there was duplicate instance naming of the buffers when the number of derived clocks was greater than 1.  This generated a synthesis error, but not a simulation error.
- For variable timestep setups, the ``emu_dt`` signal wasn't getting wired to the output of the time manager in the top level module.