### PR TITLE
Handling of VIO analog signals + Add test of msdsl functions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,34 +2,15 @@ steps:
   - command: |
       # set up environment
       source /etc/environment
-      echo $$PATH
-
-      # create virtual environment
       python3.7 -m venv venv
       source venv/bin/activate
+      printenv
 
       # upgrade pip
-      pip install -U pip
+      python -m pip install --upgrade pip
 
-      # install various python dependencies
-      pip install wheel
-      pip install pytest pytest-cov
-
-      # install anasymod
-      pip install -e .
-
-      # specify python location (needed for msdsl)
-      export PYTHON_MSDSL=`which python`
-      echo $$PYTHON_MSDSL
-
-      # run tests
-      pytest --cov-report=xml --cov=anasymod tests -v -r s
-
-      # upload coverage information
-      bash <(curl -s https://codecov.io/bash)
-
-      # deactivate virtual environment
-      deactivate
+      # run regression script
+      source regress.sh
     label: "test_emu"
     timeout_in_minutes: 60
     agents:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+    - name: Build source distribution
+      run: python setup.py sdist
+    - name: Publish source distribution to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        pip install twine
+        twine upload dist/*

--- a/anasymod/generators/gen_api.py
+++ b/anasymod/generators/gen_api.py
@@ -106,21 +106,17 @@ class SVAPI(GenAPI):
         """
 
         if direction in [PortDir.IN]:
-            if isinstance(io_obj, AnalogSignal) and not isinstance(io_obj, (AnalogCtrlInput, AnalogCtrlOutput)):
+            if isinstance(io_obj, AnalogSignal):
                 return f"`INPUT_REAL({io_obj.name})"
             elif isinstance(io_obj, (DigitalCtrlInput, DigitalCtrlOutput, DigitalSignal)):
                 width = f'[{str(io_obj.width - 1)}:0] ' if io_obj.width > 1 else ''
                 return f"input wire logic {'signed ' if io_obj.signed else ''}{width}{io_obj.name}"
-            elif isinstance(io_obj, (AnalogCtrlInput, AnalogCtrlOutput)):
-                return f"input `DATA_TYPE_REAL(`LONG_WIDTH_REAL) {io_obj.name}"
         elif direction in [PortDir.OUT]:
-            if isinstance(io_obj, AnalogSignal)and not isinstance(io_obj, (AnalogCtrlInput, AnalogCtrlOutput)):
+            if isinstance(io_obj, AnalogSignal):
                 return f"`OUTPUT_REAL({io_obj.name})"
             elif isinstance(io_obj, (DigitalCtrlInput, DigitalCtrlOutput, DigitalSignal)):
                 width = f'[{str(io_obj.width - 1)}:0] ' if io_obj.width > 1 else ''
                 return f"output wire logic {'signed ' if io_obj.signed else ''}{width}{io_obj.name}"
-            elif isinstance(io_obj, (AnalogCtrlInput, AnalogCtrlOutput)):
-                return f"output `DATA_TYPE_REAL(`LONG_WIDTH_REAL) {io_obj.name}"
         else:
             raise Exception(f"No valid direction provided: {direction}")
 
@@ -306,10 +302,6 @@ class ModuleInst():
 
         ### Check if module includes analog ports or parameters
         analog_ports = self.analog_inputs + self.analog_outputs
-        # Remove analog control signals as for those signals no parameters will be transmitted
-        for analog_port in analog_ports:
-            if isinstance(analog_port, (AnalogCtrlInput, AnalogCtrlOutput)):
-                analog_ports.remove(analog_port)
 
         if (analog_ports or self.parameters):
             self.api.writeln(f"module {self.name} #(")
@@ -354,7 +346,7 @@ class ModuleInst():
         analog_connections = []
         for connection in self.connections:
             # Remove analog control signals as for those signals no parameters will be transmitted
-            if isinstance(connection[0], AnalogSignal) and not isinstance(connection[0], (AnalogCtrlInput, AnalogCtrlOutput)):
+            if isinstance(connection[0], AnalogSignal):
                 analog_connections.append(connection)
 
         if (analog_connections or self.parameters):

--- a/anasymod/sim_ctrl/datatypes.py
+++ b/anasymod/sim_ctrl/datatypes.py
@@ -1,5 +1,6 @@
 from math import ceil, log2
 
+
 class _Signal():
     """
     Container for signals that can be used to describe connectivity within the design.
@@ -15,7 +16,9 @@ class _Signal():
         self.name = name
         self.abs_path = abspath
 
-### Digital Signal Classes
+
+# Digital Signal Classes
+
 
 class DigitalSignal(_Signal):
     """
@@ -65,7 +68,9 @@ class DigitalCtrlOutput(DigitalSignal):
         super().__init__(abspath=abspath, name=name, width=width, delimiter=delimiter)
         self.o_addr = None
 
-### Analog Signal Classes
+
+# Analog Signal Classes
+
 
 class AnalogSignal(_Signal):
     """
@@ -77,9 +82,24 @@ class AnalogSignal(_Signal):
     :param range:       Range for analog fixed-point datatype
     """
 
-    def __init__(self, abspath, name, range, delimiter='.'):
+    def __init__(self, abspath, name, range, delimiter='.', width=25):
         super().__init__(abspath=abspath, name=name, delimiter=delimiter)
         self.range = range
+        # As of now, the number of bits for each analog signal shall not be changed without also
+        # changing the corresponding value in SVREAL (LONG_WIDTH_REAL=25); in future, it shall
+        # be possible to change width for each signal
+        self.width = width
+
+    @property
+    def exponent(self):
+        return int(ceil(log2((self.range) / (2 ** (self.width - 1) - 1))))
+
+    def float_to_fixed(self, val):
+        return int(round(val*(2.0**(-self.exponent))))
+
+    def fixed_to_float(self, val):
+        return val*(2.0**(self.exponent))
+
 
 class AnalogCtrlInput(AnalogSignal):
     """
@@ -93,10 +113,11 @@ class AnalogCtrlInput(AnalogSignal):
     :param range:       Range for analog fixed-point datatype
     """
 
-    def __init__(self, abspath, name, range, init_value=0.0, delimiter='.'):
-        super().__init__(abspath=abspath, name=name, range=range, delimiter=delimiter)
+    def __init__(self, abspath, name, range, init_value=0.0, delimiter='.', width=25):
+        super().__init__(abspath=abspath, name=name, range=range, delimiter=delimiter, width=width)
         self.i_addr = None
         self.init_value = init_value
+
 
 class AnalogCtrlOutput(AnalogSignal):
     """
@@ -109,9 +130,10 @@ class AnalogCtrlOutput(AnalogSignal):
     :param range:       Range for analog fixed-point datatype
     """
 
-    def __init__(self, abspath, name, range, delimiter='.'):
-        super().__init__(abspath=abspath, name=name, range=range, delimiter=delimiter)
+    def __init__(self, abspath, name, range, delimiter='.', width=25):
+        super().__init__(abspath=abspath, name=name, range=range, delimiter=delimiter, width=width)
         self.o_addr = None
+
 
 class AnalogProbe(AnalogSignal):
     """
@@ -127,19 +149,7 @@ class AnalogProbe(AnalogSignal):
     """
 
     def __init__(self, abspath, name, range, width=25, delimiter='.'):
-        super().__init__(abspath=abspath, name=name, delimiter=delimiter, range=range)
-
-        # As of now, the number of bits for each analog signal shall not be changed without also changing the corresponding
-        # value in SVREAL (LONG_WIDTH_REAL=25); in future, it shall be possible to change width for each signal
-        self.width = width
-
-    @property
-    def exponent(self):
-        return ceil(log2((self.range) / (2 ** (self.width - 1) - 1)))
-
-
-
-
+        super().__init__(abspath=abspath, name=name, delimiter=delimiter, range=range, width=width)
 
 
 class ProbeSignal():

--- a/anasymod/structures/module_viosimctrl.py
+++ b/anasymod/structures/module_viosimctrl.py
@@ -76,6 +76,8 @@ class ModuleVIOSimCtrl(JinjaTempl):
     TEMPLATE_TEXT = '''
 `timescale 1ns/1ps
 
+`include "svreal.sv"
+
 `default_nettype none
 {{subst.module_ifc.text}}
 

--- a/anasymod/templates/vio_wiz.py
+++ b/anasymod/templates/vio_wiz.py
@@ -17,30 +17,25 @@ class TemplVIO(TemplGenericIp):
 
         # handle input ports
         for k, input in enumerate(ctrl_outputs):
-            if isinstance(input, AnalogCtrlOutput):
-                #ToDo: currently the width is set to 25 bit for all analog signals, this might be adjusted, ideally
-                # value should be set from same souce as the real.sv define for LONG_WIDTH_REAL
-                width = 25
-            elif isinstance(input, DigitalCtrlOutput):
-                width = input.width
-            else:
+            # check that the signal type can be handled
+            if not isinstance(input, (AnalogCtrlOutput, DigitalCtrlOutput)):
                 raise Exception(f"Provided signal type:{type(input)} is not supported!")
-
-            props[f'CONFIG.C_PROBE_IN{k+0}_WIDTH'] = str(width)
+            # set signal width
+            props[f'CONFIG.C_PROBE_IN{k+0}_WIDTH'] = str(input.width)
 
         # handle output ports
         for k, output in enumerate([scfg.reset_ctrl] + [scfg.dec_thr_ctrl] + crtl_inputs):
-            if isinstance(output, AnalogCtrlInput):
-                # ToDo: currently the width is set to 25 bit for all analog signals, this might be adjusted, ideally
-                #  value should be set from same souce as the real.sv define for LONG_WIDTH_REAL
-                width = 25
-            elif isinstance(output, DigitalCtrlInput):
-                width = output.width
-            else:
+            # check that the signal type can be handled
+            if not isinstance(output, (AnalogCtrlInput, DigitalCtrlInput)):
                 raise Exception(f"Provided signal type:{type(output)} is not supported!")
-            props[f'CONFIG.C_PROBE_OUT{k+0}_WIDTH'] = str(width)
+            # set signal width
+            props[f'CONFIG.C_PROBE_OUT{k + 0}_WIDTH'] = str(output.width)
+            # set initial value of probe
             if output.init_value is not None:
-                props[f'CONFIG.C_PROBE_OUT{k+0}_INIT_VAL'] = str(output.init_value)
+                init_value = output.init_value
+                if isinstance(output, AnalogCtrlInput):
+                    init_value = output.float_to_fixed(init_value)
+                props[f'CONFIG.C_PROBE_OUT{k+0}_INIT_VAL'] = str(init_value)
 
         props['CONFIG.C_NUM_PROBE_IN'] = str(len(ctrl_outputs))
         props['CONFIG.C_NUM_PROBE_OUT'] = str(len([scfg.reset_ctrl] + [scfg.dec_thr_ctrl] + crtl_inputs))

--- a/regress.sh
+++ b/regress.sh
@@ -1,0 +1,16 @@
+# install various python dependencies
+pip install wheel
+pip install pytest pytest-cov
+
+# install anasymod
+pip install -e .
+
+# specify python location (needed for msdsl)
+export PYTHON_MSDSL=`which python`
+echo $$PYTHON_MSDSL
+
+# run tests
+pytest --cov-report=xml --cov=anasymod tests -v -r s
+
+# upload coverage information
+bash <(curl -s https://codecov.io/bash)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.1'
+version = '0.2.2'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\
@@ -27,8 +27,8 @@ setup(
         ]
     },
     install_requires=[
-        'svreal>=0.2.0',
-        'msdsl>=0.1.7',
+        'svreal>=0.2.2',
+        'msdsl>=0.1.9',
         'jinja2',
         'pyvcd',
         'pyserial',

--- a/tests/function/clk_route.sv
+++ b/tests/function/clk_route.sv
@@ -1,0 +1,19 @@
+`include "svreal.sv"
+
+module clk_route (
+    output wire logic clk,
+    output wire logic rst
+);
+    // signals use for external I/O
+    (* dont_touch = "true" *) logic __emu_clk;
+    (* dont_touch = "true" *) logic __emu_rst;
+    (* dont_touch = "true" *) logic __emu_clk_val;
+    (* dont_touch = "true" *) logic __emu_clk_i;
+
+    // assign clock input (unused)
+    assign __emu_clk_i = 1'b0;
+
+    // assign outputs
+    assign clk = __emu_clk;
+    assign rst = __emu_rst;
+endmodule

--- a/tests/function/clks.yaml
+++ b/tests/function/clks.yaml
@@ -1,0 +1,4 @@
+derived_clks:
+  tb_clk:
+    abspath: 'tb_i.clk_route_i'
+    preset: fixed_timestep

--- a/tests/function/gen.py
+++ b/tests/function/gen.py
@@ -1,0 +1,53 @@
+import numpy as np
+from pathlib import Path
+from argparse import ArgumentParser
+from msdsl import MixedSignalModel, VerilogGenerator
+
+def myfunc(x):
+    # clip input
+    x = np.clip(x, -np.pi, +np.pi)
+    # apply function
+    return np.sin(x)
+
+def gen_model(order, numel, build_dir):
+    # settings:
+    # order=0, numel=512 => rms_error <= 0.0600
+    # order=1, numel=128 => rms_error <= 0.0012
+    # order=2, numel= 32 => rms_error <= 0.0010
+
+    # create mixed-signal model
+    m = MixedSignalModel('model', build_dir=build_dir)
+    m.add_analog_input('in_')
+    m.add_analog_output('out')
+    m.add_digital_input('clk')
+    m.add_digital_input('rst')
+
+    # create function
+    real_func = m.make_function(myfunc, domain=[-np.pi, +np.pi],
+                                order=order, numel=numel)
+
+    # apply function
+    m.set_from_sync_func(m.out, real_func, m.in_, clk=m.clk, rst=m.rst)
+
+    # write the model
+    return m.compile_to_file(VerilogGenerator())
+
+def main():
+    print('Running model generator...')
+
+    # parse command line arguments
+    parser = ArgumentParser()
+    parser.add_argument('-o', '--output', type=str, default='build')
+    parser.add_argument('--dt', type=float, default=0.1e-6)
+    parser.add_argument('--order', type=int, default=2)
+    parser.add_argument('--numel', type=int, default=32)
+
+    # parse arguments
+    args = parser.parse_args()
+
+    # call the model generator
+    build_dir = Path(args.output).resolve()
+    gen_model(order=args.order, numel=args.numel, build_dir=build_dir)
+
+if __name__ == '__main__':
+    main()

--- a/tests/function/prj.yaml
+++ b/tests/function/prj.yaml
@@ -1,5 +1,5 @@
 PROJECT:
   dt: 0.1e-6
-  board_name: ARTY_A7
+  board_name: ZC702
   plugins: ['msdsl']
   emu_clk_freq: 10e6

--- a/tests/function/prj.yaml
+++ b/tests/function/prj.yaml
@@ -1,0 +1,5 @@
+PROJECT:
+  dt: 0.1e-6
+  board_name: ARTY_A7
+  plugins: ['msdsl']
+  emu_clk_freq: 10e6

--- a/tests/function/sim_ctrl.sv
+++ b/tests/function/sim_ctrl.sv
@@ -59,7 +59,9 @@ module sim_ctrl #(
         // check result
         rms_err = $sqrt((1.0/n_samp)*sum_err_sqrd);
         $display("RMS error: %0f", rms_err);
-        assert (rms_err <= err_tol) else $error("RMS error is too high.");
+        if (!(rms_err <= err_tol)) begin
+            $error("RMS error is too high.");
+        end
 
         // end simulation
         $finish;

--- a/tests/function/sim_ctrl.sv
+++ b/tests/function/sim_ctrl.sv
@@ -17,7 +17,7 @@ module sim_ctrl #(
 
     // wire output
     real out_int;
-    assign out = `TO_REAL(out);
+    assign out_int = `TO_REAL(out);
 
     // clipping to range
     function real clip(input real x, input real min, input real max);
@@ -32,6 +32,7 @@ module sim_ctrl #(
 
     // run simulation
     real expct, sum_err_sqrd, rms_err;
+    integer n_samp;
     initial begin
         // wait for emulator reset to complete
         #(10us);
@@ -42,21 +43,23 @@ module sim_ctrl #(
 
         // walk through simulation values
         sum_err_sqrd = 0.0;
+        n_samp = 0;
         for (in_int=-1.2*m_pi; in_int<=+1.2*m_pi; in_int = in_int + 0.05) begin
             // wait
             #(1us);
             // compute expected output
-            expct = $sin($clip(in_int, -m_pi, +m_pi));
+            expct = $sin(clip(in_int, -m_pi, +m_pi));
             // print simulation state
             $display("in_int: %0f, out_int: %0f, expct: %0f", in_int, out_int, expct);
             // accumulate error
-            sum_err_sqrd = sum_err_sqrd + ((expct - out_int)**2)
+            sum_err_sqrd = sum_err_sqrd + ((expct - out_int)**2);
+            n_samp = n_samp + 1;
         end
 
         // check result
         rms_err = $sqrt((1.0/n_samp)*sum_err_sqrd);
         $display("RMS error: %0f", rms_err);
-        assert rms_err <= err_tol else $error("RMS error is too high.");
+        assert (rms_err <= err_tol) else $error("RMS error is too high.");
 
         // end simulation
         $finish;

--- a/tests/function/sim_ctrl.sv
+++ b/tests/function/sim_ctrl.sv
@@ -1,0 +1,64 @@
+`include "svreal.sv"
+
+module sim_ctrl #(
+    `DECL_REAL(in_),
+    `DECL_REAL(out)
+) (
+    `OUTPUT_REAL(in_),
+    `INPUT_REAL(out)
+);
+    // parameters
+    localparam real m_pi = 3.1415926535;
+    localparam real err_tol = 0.001;
+
+    // wire input
+    real in_int;
+    assign `FORCE_REAL(in_int, in_);
+
+    // wire output
+    real out_int;
+    assign out = `TO_REAL(out);
+
+    // clipping to range
+    function real clip(input real x, input real min, input real max);
+        if (x < min) begin
+            clip = min;
+        end else if (x > max) begin
+            clip = max;
+        end else begin
+            clip = x;
+        end
+    endfunction
+
+    // run simulation
+    real expct, sum_err_sqrd, rms_err;
+    initial begin
+        // wait for emulator reset to complete
+        #(10us);
+
+        // initialize signals
+        in_int = 0.0;
+        #(1us);
+
+        // walk through simulation values
+        sum_err_sqrd = 0.0;
+        for (in_int=-1.2*m_pi; in_int<=+1.2*m_pi; in_int = in_int + 0.05) begin
+            // wait
+            #(1us);
+            // compute expected output
+            expct = $sin($clip(in_int, -m_pi, +m_pi));
+            // print simulation state
+            $display("in_int: %0f, out_int: %0f, expct: %0f", in_int, out_int, expct);
+            // accumulate error
+            sum_err_sqrd = sum_err_sqrd + ((expct - out_int)**2)
+        end
+
+        // check result
+        rms_err = $sqrt((1.0/n_samp)*sum_err_sqrd);
+        $display("RMS error: %0f", rms_err);
+        assert rms_err <= err_tol else $error("RMS error is too high.");
+
+        // end simulation
+        $finish;
+    end
+endmodule

--- a/tests/function/simctrl.yaml
+++ b/tests/function/simctrl.yaml
@@ -1,0 +1,9 @@
+analog_ctrl_inputs:
+  in_:
+    abspath: 'tb_i.in_'
+    range: 10
+    init_value: 0.0
+analog_ctrl_outputs:
+  out:
+    abspath: 'tb_i.out'
+    range: 10

--- a/tests/function/source.yaml
+++ b/tests/function/source.yaml
@@ -1,0 +1,13 @@
+verilog_sources:
+  clk_route:
+    files: "clk_route.sv"
+  sim_ctrl:
+    files: "sim_ctrl.sv"
+    fileset: "sim"
+defines:
+  DT_MSDSL:
+    name: DT_MSDSL
+    value: 0.1e-6
+  SIMULATION_MODE_MSDSL:
+    name: SIMULATION_MODE_MSDSL
+    fileset: "sim"

--- a/tests/function/tb.sv
+++ b/tests/function/tb.sv
@@ -1,0 +1,25 @@
+`include "svreal.sv"
+
+module tb;
+    // signals
+    `MAKE_REAL(in_, 10.0);
+    `MAKE_REAL(out, 10.0);
+
+    // clock control
+    logic clk, rst;
+    clk_route clk_route_i (
+        .clk(clk)
+        .rst(rst)
+    );
+
+    // function
+    model #(
+       `PASS_REAL(in_, in_),
+       `PASS_REAL(out, out)
+    ) model_i (
+        .in_(in_),
+        .out(out),
+        .clk(clk),
+        .rst(rst)
+    );
+endmodule

--- a/tests/function/tb.sv
+++ b/tests/function/tb.sv
@@ -8,7 +8,7 @@ module tb;
     // clock control
     logic clk, rst;
     clk_route clk_route_i (
-        .clk(clk)
+        .clk(clk),
         .rst(rst)
     );
 

--- a/tests/function/test_function.py
+++ b/tests/function/test_function.py
@@ -62,6 +62,9 @@ def test_func_emu(gen_bitstream=True):
     err = np.linalg.norm(exact-apprx)
     assert err <= 0.001
 
+    # declare success
+    print('Success!')
+
 if __name__ == "__main__":
     # parse command-line arguments
     parser = ArgumentParser()

--- a/tests/function/test_function.py
+++ b/tests/function/test_function.py
@@ -1,0 +1,80 @@
+import os
+import numpy as np
+from argparse import ArgumentParser
+from time import sleep
+
+from anasymod.analysis import Analysis
+
+root = os.path.dirname(__file__)
+
+def myfunc(x):
+    # clip input
+    x = np.clip(x, -np.pi, +np.pi)
+    # apply function
+    return np.sin(x)
+
+def test_func_sim(simulator_name='vivado'):
+    # create analysis object
+    ana = Analysis(input=root,
+                   simulator_name=simulator_name)
+    # generate functional models
+    ana.msdsl.models()
+    # setup project's filesets
+    ana.setup_filesets()
+    # run the simulation
+    ana.simulate()
+
+def test_func_emu(gen_bitstream=True):
+    # create analysis object
+    ana = Analysis(input=root)
+    # generate functional models
+    ana.msdsl.models()
+    ana.setup_filesets()
+    ana.set_target(target_name='fpga')      # set the active target to 'fpga'
+
+    if gen_bitstream:
+        ana.build()                         # generate bitstream for project
+
+    ctrl = ana.launch(debug=True)           # start interactive control
+
+    # reset emulator
+    ctrl.set_reset(1)
+    sleep(0.1)
+    ctrl.set_reset(0)
+    sleep(0.1)
+
+    # reset everything else
+    ctrl.set_param(name='in_', value=0.0)
+
+    # save the outputs
+    inpts = np.random.uniform(-1.2*np.pi, +1.2*np.pi, 100)
+    apprx = np.zeros(shape=inpts.shape, dtype=float)
+    for k, in_ in enumerate(inpts):
+        ctrl.set_param(name='in_', value=in_)
+        sleep(1e-3)
+        ctrl.refresh_param('vio_0_i')
+        apprx[k] = ctrl.get_param('out')
+
+    # compute the exact response to inputs
+    exact = myfunc(inpts)
+
+    # check the result
+    err = np.linalg.norm(exact-apprx)
+    assert err <= 0.001
+
+if __name__ == "__main__":
+    # parse command-line arguments
+    parser = ArgumentParser()
+    parser.add_argument('--sim', action='store_true')
+    parser.add_argument('--emulate', action='store_true')
+    parser.add_argument('--gen_bitstream', action='store_true')
+    parser.add_argument('--simulator_name', type=str, default=None)
+    args = parser.parse_args()
+
+    # run actions as requested
+    if args.sim:
+        print('Running simulation...')
+        test_func_sim(simulator_name=args.simulator_name)
+    if args.emulate:
+        print('Running emulation...')
+        test_func_emu(gen_bitstream=args.gen_bitstream)

--- a/tests/rc/simctrl.yaml
+++ b/tests/rc/simctrl.yaml
@@ -1,21 +1,18 @@
-analog_probes:
-  v_out_ila:
+analog_ctrl_inputs:
+  v_in:
+    abspath: 'tb_i.v_in'
+    range: 10
+    init_value: 0.0
+analog_ctrl_outputs:
+  v_out:
     abspath: 'tb_i.v_out'
-    range: 64
+    range: 10
 digital_ctrl_inputs:
   go_vio:
     abspath: 'tb_i.go_vio'
     width: 1
-    init_value: 0x0
+    init_value: 0
   rst_vio:
     abspath: 'tb_i.rst_vio'
     width: 1
-    init_value: 0x1
-  v_in_vio:
-    abspath: 'tb_i.v_in_vio'
-    width: 25
-    init_value: 0x0
-digital_ctrl_outputs:
-  v_out_vio:
-    abspath: 'tb_i.v_out_vio'
-    width: 25
+    init_value: 1

--- a/tests/rc/source.yaml
+++ b/tests/rc/source.yaml
@@ -8,9 +8,6 @@ defines:
   DT_MSDSL:
     name: DT_MSDSL
     value: 0.1e-6
-  ANALOG_EXPONENT:
-    name: ANALOG_EXPONENT
-    value: -18
   SIMULATION_MODE_MSDSL:
     name: SIMULATION_MODE_MSDSL
     fileset: "sim"

--- a/tests/rc/tb.sv
+++ b/tests/rc/tb.sv
@@ -1,18 +1,12 @@
 `include "svreal.sv"
 
 module tb;
-    // signals
-    logic signed [24:0] v_in_vio;
-    logic signed [24:0] v_out_vio;
-    logic go_vio;
-    logic rst_vio;
-    logic clk;
+    // analog signals
+    `MAKE_REAL(v_in, 10.0);
+    `MAKE_REAL(v_out, 10.0);
 
-    // declare SVREAL signals
-    `REAL_FROM_WIDTH_EXP(v_in, 25, `ANALOG_EXPONENT);
-    `REAL_FROM_WIDTH_EXP(v_out, 25, `ANALOG_EXPONENT);
-    assign v_in = v_in_vio;
-    assign v_out_vio = v_out;
+    // control signals
+    logic go_vio, rst_vio, clk;
 
     // clock control
     single_step_clk clk_gen (

--- a/tests/rc/test_rc.py
+++ b/tests/rc/test_rc.py
@@ -8,14 +8,6 @@ from math import exp
 
 root = os.path.dirname(__file__)
 
-ANALOG_EXPONENT = -18
-
-def float_to_fixed(x):
-    return int(x * (2.0**(-ANALOG_EXPONENT)))
-
-def fixed_to_float(x):
-    return x * (2.0**(ANALOG_EXPONENT))
-
 def test_rc_sim(simulator_name='vivado'):
     # create analysis object
     ana = Analysis(input=root,
@@ -56,7 +48,7 @@ def test_rc_emu(gen_bitstream=True):
     # reset everything else
     ctrl.set_param(name='go_vio', value=0)
     ctrl.set_param(name='rst_vio', value=1)
-    ctrl.set_param(name='v_in_vio', value=float_to_fixed(1.0))
+    ctrl.set_param(name='v_in', value=1.0)
 
     # pulse the clock
     pulse_clock()
@@ -72,13 +64,13 @@ def test_rc_emu(gen_bitstream=True):
     for _ in range(25):
         # get readings
         ctrl.refresh_param('vio_0_i')
-        v_out_vio = fixed_to_float(int(ctrl.get_param('v_out_vio')))
+        v_out = ctrl.get_param('v_out')
 
         # print readings
-        print(f't_sim: {t_sim}, v_out_vio: {v_out_vio}')
+        print(f't_sim: {t_sim}, v_out: {v_out}')
 
         # check results
-        meas_val = v_out_vio
+        meas_val = v_out
         expt_val = 1.0 - exp(-t_sim / tau)
         assert (expt_val - abs_tol) <= meas_val <= (expt_val + abs_tol), 'Measured value is out of range.'
 
@@ -87,6 +79,9 @@ def test_rc_emu(gen_bitstream=True):
 
         # update the time variable
         t_sim += 0.1e-6
+
+    # declare success
+    print('Success!')
 
 if __name__ == "__main__":
     # parse command-line arguments


### PR DESCRIPTION
## Summary
This PR mainly has to do with reading / writing analog signals using the VIO and the ``sim_ctrl`` module.  

## Update to analog control signals
1. Default values for VIO analog inputs are now treated as real numbers, and converted to the appropriate fixed-point representation.  In other words, the initial value specified for analog control inputs in ``simctrl.yaml`` should be a real value.
2. The function ``set_param`` now takes a real value and converts it to the appropriate fixed-point representation (for analog control inputs only; the behavior for digital control inputs is unaffected.)
3. Similarly, the value returned by ``get_param`` is now a real number (for analog control outputs only)
4. Analog I/O in the ``sim_ctrl`` module is now handled using the svreal macros `` `DECL_REAL ``, `` `INPUT_REAL `` and `` `OUTPUT_REAL ``.  This works because the generated top-level verilog now uses `` `PASS_REAL `` to pass formatting information.  One advantage of this approach is that is is possible to switch to a floating-point representation for ``sim_ctrl`` by setting the `` `FLOAT_REAL `` flag.
5. The ``rc`` regression testing example is updated to use these new features.

## Other changes
1. Added a new regression test called ``function`` that implements a sine function using the new ``make_function`` feature from msdsl.
2. Added a GitHub action for releasing to PyPI
3. Refactored the regression script into a file called ``regress.sh``
4. Bumped the anasymod version to ``0.2.2``