### PR TITLE
Vitis support

### DIFF
--- a/anasymod/analysis.py
+++ b/anasymod/analysis.py
@@ -341,7 +341,7 @@ class Analysis():
         # build the firmware
         XSCTEmulation(target=target).build(*args, **kwargs)
 
-    def emulate(self, server_addr=None):
+    def emulate(self, server_addr=None, convert_waveform=True):
         """
         Program bitstream to FPGA and run simulation/emulation on FPGA
 
@@ -375,14 +375,15 @@ class Analysis():
         statpro.statpro_update(statpro.FEATURES.anasymod_emulate_vivado)
 
         # post-process results
-        ConvertWaveform(
-            result_path_raw=target.result_path_raw,
-            result_type_raw=target.cfg.result_type_raw,
-            result_path=target.cfg.vcd_path,
-            str_cfg=target.str_cfg,
-            float_type=self.float_type,
-            dt_scale=self._prj_cfg.cfg.dt_scale
-        )
+        if convert_waveform:
+            ConvertWaveform(
+                result_path_raw=target.result_path_raw,
+                result_type_raw=target.cfg.result_type_raw,
+                result_path=target.cfg.vcd_path,
+                str_cfg=target.str_cfg,
+                float_type=self.float_type,
+                dt_scale=self._prj_cfg.cfg.dt_scale
+            )
 
     def program_firmware(self, *args, **kwargs):
         # create target object, but don't generate instrumentation structure again in case target object does not exist yet
@@ -434,7 +435,7 @@ class Analysis():
         #ToDo: once recording via ila in interactive mode is finishe and caotured results were dumped into a file,
         #ToDo: the conversion step to .vcd needs to be triggered via some command
 
-    def simulate(self, unit=None, id=None):
+    def simulate(self, unit=None, id=None, convert_waveform=True):
         """
         Run simulation on a pc target.
         """
@@ -471,12 +472,15 @@ class Analysis():
         statpro.statpro_update(statpro.FEATURES.anasymod_sim + self.args.simulator_name)
 
         # post-process results
-        ConvertWaveform(result_path_raw=target.result_path_raw,
-                        result_type_raw=target.cfg.result_type_raw,
-                        result_path=target.cfg.vcd_path,
-                        str_cfg=target.str_cfg,
-                        float_type=self.float_type,
-                        debug=self._prj_cfg.cfg.cpu_debug_mode)
+        if convert_waveform:
+            ConvertWaveform(
+                result_path_raw=target.result_path_raw,
+                result_type_raw=target.cfg.result_type_raw,
+                result_path=target.cfg.vcd_path,
+                str_cfg=target.str_cfg,
+                float_type=self.float_type,
+                debug=self._prj_cfg.cfg.cpu_debug_mode
+            )
 
     def probe(self, name, emu_time=False):
         """

--- a/anasymod/analysis.py
+++ b/anasymod/analysis.py
@@ -328,7 +328,7 @@ class Analysis():
         VivadoEmulation(target=target).build()
         statpro.statpro_update(statpro.FEATURES.anasymod_build_vivado)
 
-    def build_firmware(self):
+    def build_firmware(self, *args, **kwargs):
         # create target object, but don't generate instrumentation structure again in case target object does not exist yet
         if not hasattr(self, self.act_fpga_target):
             self._setup_targets(target=self.act_fpga_target)
@@ -339,7 +339,7 @@ class Analysis():
             raise Exception(f'Bitstream for active FPGA target was not generated beforehand; please do so before running emulation.')
 
         # build the firmware
-        XSCTEmulation(target=target).build()
+        XSCTEmulation(target=target).build(*args, **kwargs)
 
     def emulate(self, server_addr=None):
         """
@@ -384,7 +384,7 @@ class Analysis():
             dt_scale=self._prj_cfg.cfg.dt_scale
         )
 
-    def program_firmware(self):
+    def program_firmware(self, *args, **kwargs):
         # create target object, but don't generate instrumentation structure again in case target object does not exist yet
         if not hasattr(self, self.act_fpga_target):
             self._setup_targets(target=self.act_fpga_target)
@@ -395,7 +395,7 @@ class Analysis():
             raise Exception(f'Bitstream for active FPGA target was not generated beforehand; please do so before running emulation.')
 
         # build the firmware
-        XSCTEmulation(target=target).program()
+        XSCTEmulation(target=target).program(*args, **kwargs)
 
     def launch(self, server_addr=None, debug=False):
         """

--- a/anasymod/config.py
+++ b/anasymod/config.py
@@ -329,6 +329,13 @@ class Config(BaseConfig):
             design modules, for which all signals shall be stored in result file. e.g.:
             [(0, top.tb_i.filter_i)]"""
 
+        self.flatten_hierarchy = 'rebuilt'
+        """ type(str) : Flattening strategy used in synthesis by Vivado.  Can be 'none', 'full', or 'rebuilt'.
+            Choosing 'none' is a good strategy for debugging synthesis issues, while 'full' may allow for
+            better synthesis results.  'rebuilt' is a trade-off between readability and performance, but
+            sometimes has bugs, particularly when more complex Verilog features like hierarchical references and
+            interfaces are used."""
+
 def find_tool(name, hints=None, sys_path_hint=True):
     # set defaults
     if hints is None:

--- a/anasymod/config.py
+++ b/anasymod/config.py
@@ -1,4 +1,6 @@
 import os.path
+import pathlib
+import re
 import multiprocessing
 import shutil
 
@@ -104,7 +106,8 @@ class EmuConfig:
             raise Exception(f'The requested board {self.cfg.board_name} could not be found.')
 
 class VivadoConfig():
-    def __init__(self, parent: EmuConfig, vivado=None):
+    def __init__(self, parent: EmuConfig, vivado=None, version=None,
+                 version_year=None, version_number=None):
         # save reference to parent config
         self.parent = parent
 
@@ -128,6 +131,12 @@ class VivadoConfig():
                 self.lsf_opts_ls = "-eh_ram 70000 -eh_ncpu 8 -eh_dispatch LS_SHELL"
 
         self._vivado = vivado
+
+        # version, year, number
+        self._version = version
+        self._version_year = version_year
+        self._version_number = version_number
+
         # set various project options
         self.num_cores = multiprocessing.cpu_count()
         self.vio_name = 'vio_0'
@@ -141,6 +150,26 @@ class VivadoConfig():
         if self._vivado is None:
             self._vivado = find_tool(name='vivado', hints=self.hints)
         return self._vivado
+
+    @property
+    def version(self):
+        if self._version is None:
+            self._version = pathlib.Path(self.vivado).parent.parent.name
+        return self._version
+
+    @property
+    def version_year(self):
+        if self._version_year is None:
+            self._version_year = re.match(r'(\d+)\.(\d+)', self.version).groups()[0]
+            self._version_year = int(self._version_year)
+        return self._version_year
+
+    @property
+    def version_number(self):
+        if self._version_number is None:
+            self._version_number = re.match(r'(\d+)\.(\d+)', self.version).groups()[1]
+            self._version_number = int(self._version_number)
+        return self._version_number
 
 class XceliumConfig():
     def __init__(self, parent: EmuConfig, xrun=None):

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -104,16 +104,25 @@ class VivadoEmulation(VivadoTCLGenerator):
         self.writeln(f'launch_runs impl_1 -to_step write_bitstream -jobs {num_cores}')
         self.writeln('wait_on_run impl_1')
 
-        # re-generate the LTX file
-        # without this step, the ILA probes are sometimes split into individual bits
-        ltx_file_path = os.path.join(
+        # open the impl_1 run and determine its location
+        self.writeln('open_run impl_1')
+        impl_dir = os.path.join(
             self.target.project_root,
             f'{self.target.prj_cfg.vivado_config.project_name}.runs',
             'impl_1',
-            f'{self.target.cfg.top_module}.ltx'
         )
-        self.writeln('open_run impl_1')
+
+        # re-generate the LTX file
+        # without this step, the ILA probes are sometimes split into individual bits
+        ltx_file_path = os.path.join(impl_dir, f'{self.target.cfg.top_module}.ltx')
+        ltx_file_path = back2fwd(ltx_file_path)
         self.writeln(f'write_debug_probes -force {{{back2fwd(ltx_file_path)}}}')
+
+        # export the XSA if this is a more recent version of vivado
+        if self.version_year >= 2020:
+            xsa_file_path = os.path.join(impl_dir, f'{self.target.cfg.top_module}.xsa')
+            xsa_file_path = back2fwd(xsa_file_path)
+            self.writeln(f'write_hw_platform -fixed -include_bit -force -file {{{xsa_file_path}}}')
 
         # run bitstream generation
         self.run(filename=r"bitstream.tcl")

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -44,6 +44,13 @@ class VivadoEmulation(VivadoTCLGenerator):
         # set define variables
         self.add_project_defines(content=self.target.content, fileset='[current_fileset]')
 
+        # specify the level of flattening to use
+        self.set_property(
+            'STEPS.SYNTH_DESIGN.ARGS.FLATTEN_HIERARCHY',
+            self.target.prj_cfg.cfg.flatten_hierarchy,
+            '[get_runs synth_1]'
+        )
+
         # append user constraints
         for xdc_file in self.target.content.xdc_files:
             for file in xdc_file.files:

--- a/anasymod/emu/xsct_emu.py
+++ b/anasymod/emu/xsct_emu.py
@@ -15,43 +15,64 @@ class XSCTEmulation(XSCTTCLGenerator):
     def __init__(self, target: FPGATarget):
         super().__init__(target=target)
 
-    def build(self):
+    @property
+    def impl_dir(self):
+        return (
+            Path(self.target.project_root) /
+            f'{self.target.prj_cfg.vivado_config.project_name}.runs' /
+            'impl_1'
+        )
+
+    @property
+    def bit_path(self):
+        return self.impl_dir / f'{self.target.cfg.top_module}.bit'
+
+    @property
+    def tcl_path(self):
+        return self.impl_dir / 'ps7_init.tcl'
+
+    @property
+    def hw_path(self):
+        if self.version_year < 2020:
+            return self.impl_dir / f'{self.target.cfg.top_module}.sysdef'
+        else:
+            return self.impl_dir / f'{self.target.cfg.top_module}.xsa'
+
+    def build(self, create=True, copy_files=True, build=True):
         # determine SDK path
         sdk_path = (Path(self.target.project_root) /
                     f'{self.target.prj_cfg.vivado_config.project_name}.sdk')
-        hdf_path = sdk_path / f'{self.target.cfg.top_module}.hdf'
 
         # clear the SDK directory
-        shutil.rmtree(sdk_path, ignore_errors=True)
-        sdk_path.mkdir(exist_ok=True, parents=True)
-
-        # export the hardware
-        sysdef_path = (Path(self.target.project_root) /
-                       f'{self.target.prj_cfg.vivado_config.project_name}.runs' /
-                       'impl_1' /
-                       f'{self.target.cfg.top_module}.sysdef')
-        shutil.copy(str(sysdef_path), str(hdf_path))
+        if create:
+            shutil.rmtree(sdk_path, ignore_errors=True)
+            sdk_path.mkdir(exist_ok=True, parents=True)
 
         # copy over the firmware sources
-        src_path = sdk_path / 'sw' / 'src'
-        src_path.mkdir(exist_ok=True, parents=True)
-        for src in self.target.content.firmware_files:
-            if src.files is not None:
-                for file_ in src.files:
-                    shutil.copy(str(file_), str(src_path / Path(file_).name))
+        if copy_files:
+            src_path = sdk_path / 'sw' / 'src'
+            src_path.mkdir(exist_ok=True, parents=True)
+            for src in self.target.content.firmware_files:
+                if src.files is not None:
+                    for file_ in src.files:
+                        shutil.copy(str(file_), str(src_path / Path(file_).name))
 
         # generate the build script
         self.write(
             TemplXSCTBuild(
                 sdk_path=sdk_path,
-                top_name=f'{self.target.cfg.top_module}'
+                hw_path=self.hw_path,
+                version_year=self.version_year,
+                version_number=self.version_number,
+                create=create,
+                build=build
             ).text
         )
 
         # run the build script
         self.run('sdk.tcl')
 
-    def program(self):
+    def program(self, program_fpga=True, reset_system=True):
         # determine SDK path
         sdk_path = (Path(self.target.project_root) /
                     f'{self.target.prj_cfg.vivado_config.project_name}.sdk')
@@ -60,7 +81,11 @@ class XSCTEmulation(XSCTTCLGenerator):
         self.write(
             TemplXSCTProgram(
                 sdk_path=sdk_path,
-                top_name=f'{self.target.cfg.top_module}'
+                bit_path=self.bit_path,
+                hw_path=self.hw_path,
+                tcl_path=self.tcl_path,
+                program_fpga=program_fpga,
+                reset_system=reset_system
             ).text
         )
 

--- a/anasymod/generators/vivado.py
+++ b/anasymod/generators/vivado.py
@@ -166,3 +166,11 @@ class VivadoTCLGenerator(CodeGenerator):
 
         # run the script
         call(args=cmd, cwd=self.target.prj_cfg.build_root, err_str=err_str)
+
+    @property
+    def version_year(self):
+        return self.target.prj_cfg.vivado_config.version_year
+
+    @property
+    def version_number(self):
+        return self.target.prj_cfg.vivado_config.version_number

--- a/anasymod/generators/xsct.py
+++ b/anasymod/generators/xsct.py
@@ -1,3 +1,6 @@
+import pathlib
+import re
+import shutil
 from pathlib import Path
 
 from anasymod.util import call
@@ -9,8 +12,14 @@ class XSCTTCLGenerator(CodeGenerator):
     Class for generating TCL scripts for XSCT
     """
 
-    def __init__(self, target: FPGATarget):
+    def __init__(self, target: FPGATarget, xsct=None, version=None,
+                 version_year=None, version_number=None):
         super().__init__()
+
+        self._xsct = xsct
+        self._version = version
+        self._version_year = version_year
+        self._version_number = version_number
         self.target = target
 
     def run(self, filename=r'run.tcl', err_str=None):
@@ -19,7 +28,33 @@ class XSCTTCLGenerator(CodeGenerator):
         self.write_to_file(tcl_script)
 
         # assemble the command
-        cmd = ['xsct', str(tcl_script)]
+        cmd = [str(self.xsct), str(tcl_script)]
 
         # run the script
         call(args=cmd, err_str=err_str)
+
+    @property
+    def xsct(self):
+        if self._xsct is None:
+            self._xsct = shutil.which('xsct')
+        return self._xsct
+
+    @property
+    def version(self):
+        if self._version is None:
+            self._version = pathlib.Path(self.xsct).parent.parent.name
+        return self._version
+
+    @property
+    def version_year(self):
+        if self._version_year is None:
+            self._version_year = re.match(r'(\d+)\.(\d+)', self.version).groups()[0]
+            self._version_year = int(self._version_year)
+        return self._version_year
+
+    @property
+    def version_number(self):
+        if self._version_number is None:
+            self._version_number = re.match(r'(\d+)\.(\d+)', self.version).groups()[1]
+            self._version_number = int(self._version_number)
+        return self._version_number

--- a/anasymod/templates/xsct_build.py
+++ b/anasymod/templates/xsct_build.py
@@ -1,22 +1,67 @@
 class TemplXSCTBuild:
-    def __init__(self, sdk_path, proc_name='ps7_cortexa9_0',
-                 hw_name='hw', top_name='top', sw_name='sw'):
+    def __init__(self, sdk_path, version_year, version_number,
+                 proc_name='ps7_cortexa9_0', os_name='standalone',
+                 hw_name='hw', hw_path=None, sw_name='sw',
+                 template_name='Empty Application', create=True,
+                 build=True):
 
-        self.text = f'''\
-# set the work directory
-setws "{sdk_path}"
+        # save version information
+        self.version_year = version_year
+        self.version_number = version_number
 
-# create the hardware configuration
-createhw \\
-    -name {hw_name} \\
-    -hwspec "{sdk_path / top_name}.hdf"
+        # initialize text
+        self.text = ''
 
-# create the software configuration
-createapp \\
-    -name {sw_name} \\
-    -hwproject {hw_name} \\
-    -proc {proc_name} \\
-    -app "Empty Application"
+        # apply commands
 
-# build application
-projects -build'''
+        self.setws(sdk_path=sdk_path)
+
+        if create:
+            self.app_create(
+                hw_name=hw_name,
+                hw_path=hw_path,
+                sw_name=sw_name,
+                proc_name=proc_name,
+                template_name=template_name,
+                os_name=os_name
+            )
+
+        if build:
+            self.app_build(
+                sw_name=sw_name
+            )
+
+    def line(self, s='', nl='\n'):
+        self.text += f'{s}{nl}'
+
+    def comment(self, s):
+        self.line(f'# {s}')
+
+    def setws(self, sdk_path):
+        self.comment('set the work directory')
+        self.line(f'setws "{sdk_path}"')
+        self.line()
+
+    def app_create(self, hw_name, hw_path, sw_name, proc_name,
+                   template_name, os_name):
+        if self.version_year < 2020:
+            self.comment('create the hardware configuration')
+            self.line(f'createhw -name {hw_name} -hwspec "{hw_path}"')
+            self.line()
+            self.comment('create the software configuration')
+            self.line(f'createapp -name {sw_name} -hwproject {hw_name} '
+                      f'-proc {proc_name} -app "{template_name}"')
+            self.line()
+        else:
+            self.comment('create the app configuration')
+            self.line(f'app create -name {sw_name} -hw "{hw_path}" -os {os_name}'
+                      f' -proc {proc_name} -template "{template_name}"')
+            self.line()
+
+    def app_build(self, sw_name):
+        self.comment('build application')
+        if self.version_year < 2020:
+            self.line('projects -build')
+        else:
+            self.line(f'app build -name {sw_name}')
+        self.line()

--- a/anasymod/templates/xsct_program.py
+++ b/anasymod/templates/xsct_program.py
@@ -1,46 +1,81 @@
-class TemplXSCTProgram:
-    def __init__(self, sdk_path, cpu_filter='"ARM*#0"', hw_name='hw',
-                 top_name='top', sw_name='sw'):
-
-        self.text = f'''\
 # References:
 # 1. https://www.xilinx.com/html_docs/xilinx2018_1/SDK_Doc/xsct/use_cases/xsdb_standalone_app_debug.html
 # 2. https://github.com/Digilent/Arty-Z7-20-linux_bd/blob/master/sdk/.sdk/launch_scripts/xilinx_c-c%2B%2B_application_(system_debugger)/system_debugger_using_debug_video.elf_on_local.tcl
-    
-# connect to the HW server
-puts "Connecting to the HW server..."
-connect
+# 3. https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842240/Programming+QSPI+from+U-boot+ZC702
 
-# select the CPU
-puts "Selecting the CPU..."
-targets -set -filter {{name =~ {cpu_filter}}}
+class TemplXSCTProgram:
+    def __init__(self, sdk_path, bit_path, hw_path, tcl_path, cpu_filter='"ARM*#0"',
+                 sw_name='sw', program_fpga=True, reset_system=True):
 
-# reset the system
-puts "Resetting the system..."
-rst
+        # initialize text
+        self.text = ''
 
-# program the FPGA
-puts "Programming the FPGA..."
-fpga "{sdk_path / hw_name / top_name}.bit"
+        # apply commands
 
-# make the debugger aware of the memory map
-# TODO: is this needed?
-puts "Setting up the debugger..."
-loadhw "{sdk_path / top_name}.hdf"
+        self.connect()
 
-# initialize the processor
-puts "Initializing the processor..."
-source "{sdk_path / hw_name / 'ps7_init'}.tcl"
-ps7_init
-ps7_post_config
+        self.select_cpu(cpu_filter)
 
-# download the program
-puts "Downloading the program..."
-dow "{sdk_path / sw_name / 'Debug' / sw_name}.elf"
+        if reset_system:
+            self.reset_system()
 
-# run program
-puts "Starting the program..."
-con
+        if program_fpga:
+            self.program_fpga(bit_path)
 
-# print message for debugging purposes
-puts "Program started."'''
+        self.loadhw(hw_path)
+
+        self.init_cpu(tcl_path)
+
+        self.download(str(sdk_path / sw_name / 'Debug' / sw_name) + '.elf')
+
+        self.run()
+
+        self.puts("Program started.")
+
+    def line(self, s='', nl='\n'):
+        self.text += f'{s}{nl}'
+
+    def puts(self, s):
+        self.line(f'puts "{s}"')
+
+    def connect(self):
+        self.puts('Connecting to the HW server...')
+        self.line('connect')
+        self.line()
+
+    def select_cpu(self, cpu_filter):
+        self.puts('Selecting the CPU...')
+        self.line(f'targets -set -filter {{name =~ {cpu_filter}}}')
+        self.line()
+
+    def reset_system(self):
+        self.puts('Resetting the system...')
+        self.line('rst')
+        self.line()
+
+    def program_fpga(self, bit_path):
+        self.puts('Programming the FPGA...')
+        self.line(f'fpga "{bit_path}"')
+        self.line()
+
+    def loadhw(self, hw_path):
+        self.puts('Setting up the debugger...')
+        self.line(f'loadhw "{hw_path}"')
+        self.line()
+
+    def init_cpu(self, tcl_path):
+        self.puts('Initializing the processor...')
+        self.line(f'source "{tcl_path}"')
+        self.line('ps7_init')
+        self.line('ps7_post_config')
+        self.line()
+
+    def download(self, elf_path):
+        self.puts('Downloading the program...')
+        self.line(f'dow "{elf_path}"')
+        self.line()
+
+    def run(self):
+        self.puts('Starting the program...')
+        self.line('con')
+        self.line()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.6'
+version = '0.2.7'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.7'
+version = '0.2.8'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.2.8'
+version = '0.2.9'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/tests/firmware/test_firmware.py
+++ b/tests/firmware/test_firmware.py
@@ -51,7 +51,7 @@ def test_4():
 def test_5():
     # run UART test
     ser = serial.Serial(
-        port='/dev/ttyUSB0',
+        port='/dev/ttyUSB2',
         baudrate=115200
     )
 


### PR DESCRIPTION
This PR adds support for Vitis (specifically Xilinx Unified 2020.1) with some updates to the way firmware is built and uploaded to the Zynq PS.  Where required, the Xilinx software version number is checked to determine how to form TCL commands, so support for older Xilinx versions should be preserved.

Two other small changes are included:
1. The project config YAML now supports an option called ``flatten_hierarchy``, which can be ``none``, ``full``, or ``rebuilt``, with the same meaning as in the Vivado GUI (default is ``rebuilt``).  Using ``none`` is often a helpful workaround for Vivado synthesis bugs in complex designs.
2. The ``simulate`` and ``emulate`` commands for the ``Analysis`` object now have an option called ``convert_waveforms`` (defaults to ``True``).  If this option is set to ``False``, then CSV/VCD post-processing will not be performed.  This can save time if raw waveform files are large and will be inspected directly anyway, and it is also a helpful "escape hatch" if there is an error in the post-processing routine.