### PR TITLE
Add support for ZCU106 board

### DIFF
--- a/anasymod/config.py
+++ b/anasymod/config.py
@@ -340,6 +340,11 @@ class Config(BaseConfig):
             sometimes has bugs, particularly when more complex Verilog features like hierarchical references and
             interfaces are used."""
 
+        self.vivado_stack = None
+        """ type(int) : Stack size used by Vivado.  If you are getting an error during synthesis that
+            looks like "Segmentation fault "$RDI_PROG"", try setting this to 2000 or higher
+            (https://www.xilinx.com/support/answers/64434.html)."""
+
 def find_tool(name, hints=None, sys_path_hint=True):
     # set defaults
     if hints is None:

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -146,7 +146,7 @@ class VivadoEmulation(VivadoTCLGenerator):
                 self.writeln('exec subst ' + self.subst + ' ' + self.old_subst)
 
         # run bitstream generation
-        self.run(filename=r"bitstream.tcl")
+        self.run(filename=r"bitstream.tcl", stack=self.target.prj_cfg.cfg.vivado_stack)
 
     def run_FPGA(self, **kwargs):
         """

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -111,7 +111,7 @@ class VivadoEmulation(VivadoTCLGenerator):
         # create block diagram if needed
         # TODO: pass through configuration options
         if self.target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ:
-            self.use_templ(TemplZynqGPIO(scfg.is_ultrascale))
+            self.use_templ(TemplZynqGPIO(is_ultrascale=scfg.is_ultrascale))
 
         # launch the build and wait for it to finish
         num_cores = min(int(self.target.prj_cfg.vivado_config.num_cores), 8)

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -111,7 +111,7 @@ class VivadoEmulation(VivadoTCLGenerator):
         # create block diagram if needed
         # TODO: pass through configuration options
         if self.target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ:
-            self.writeln(TemplZynqGPIO().text)
+            self.use_templ(TemplZynqGPIO(scfg.is_ultrascale))
 
         # launch the build and wait for it to finish
         num_cores = min(int(self.target.prj_cfg.vivado_config.num_cores), 8)

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -89,6 +89,13 @@ class VivadoEmulation(VivadoTCLGenerator):
             # Setup Debug Hub
             constrs.use_templ(TemplDbgHub(target=self.target))
 
+            # Add false paths for Zynq control signals.  This is necessary in some cases
+            # to provide timing violations, since the ARM core is running on a different
+            # clock that the emulator circuitry.  This is a real problem, but is handled
+            # in firmware with handshaking and very short delays.
+            if self.target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ:
+                constrs.writeln('set_false_path -through [get_pins sim_ctrl_gen_i/zynq_gpio_i/*]')
+
             # write master constraints to file and add to project
             master_constr_path = os.path.join(self.target.prj_cfg.build_root, 'constrs.xdc')
             constrs.write_to_file(master_constr_path)

--- a/anasymod/emu/xsct_emu.py
+++ b/anasymod/emu/xsct_emu.py
@@ -97,6 +97,7 @@ class XSCTEmulation(XSCTTCLGenerator):
                 hw_path=self.hw_path,
                 tcl_path=self.tcl_path,
                 is_ultrascale=self.target.prj_cfg.board.is_ultrascale,
+                xsct_install_dir=self.xsct_install_dir,
                 **kwargs
             ).text
         )

--- a/anasymod/emu/xsct_emu.py
+++ b/anasymod/emu/xsct_emu.py
@@ -84,7 +84,7 @@ class XSCTEmulation(XSCTTCLGenerator):
         err_str = re.compile(r'(: error:)|(make.*: \*\*\* .* Error \d+)')
         self.run('sdk.tcl', err_str=err_str)
 
-    def program(self, program_fpga=True, reset_system=True):
+    def program(self, **kwargs):
         # determine SDK path
         sdk_path = (Path(self.target.project_root) /
                     f'{self.target.prj_cfg.vivado_config.project_name}.sdk')
@@ -96,8 +96,8 @@ class XSCTEmulation(XSCTTCLGenerator):
                 bit_path=self.bit_path,
                 hw_path=self.hw_path,
                 tcl_path=self.tcl_path,
-                program_fpga=program_fpga,
-                reset_system=reset_system
+                is_ultrascale=self.target.prj_cfg.board.is_ultrascale,
+                **kwargs
             ).text
         )
 

--- a/anasymod/emu/xsct_emu.py
+++ b/anasymod/emu/xsct_emu.py
@@ -30,7 +30,10 @@ class XSCTEmulation(XSCTTCLGenerator):
 
     @property
     def tcl_path(self):
-        return self.impl_dir / 'ps7_init.tcl'
+        if self.target.prj_cfg.board.is_ultrascale:
+            return self.impl_dir / 'psu_init.tcl'
+        else:
+            return self.impl_dir / 'ps7_init.tcl'
 
     @property
     def hw_path(self):
@@ -58,6 +61,12 @@ class XSCTEmulation(XSCTTCLGenerator):
                     for file_ in src.files:
                         shutil.copy(str(file_), str(src_path / Path(file_).name))
 
+        # determine the processor name
+        if self.target.prj_cfg.board.is_ultrascale:
+            proc_name = 'psu_cortexa53_0'
+        else:
+            proc_name = 'ps7_cortexa9_0'
+
         # generate the build script
         self.write(
             TemplXSCTBuild(
@@ -65,6 +74,7 @@ class XSCTEmulation(XSCTTCLGenerator):
                 hw_path=self.hw_path,
                 version_year=self.version_year,
                 version_number=self.version_number,
+                proc_name=proc_name,
                 create=create,
                 build=build
             ).text

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -120,5 +120,5 @@ class ZCU106(FPGA_Board):
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_vid = 4292
     uart_pid = 60017
-    uart_suffix = '.3'  # needed since this board has four com ports under the same VID/PID
+    uart_suffix = '.0'  # needed since this board has four com ports under the same VID/PID
     is_ultrascale = True

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -119,5 +119,6 @@ class ZCU106(FPGA_Board):
     short_part_name = 'xczu7ev'
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_vid = 4292
-    uart_pid = 60000
+    uart_pid = 60017
+    uart_suffix = '.3'  # needed since this board has four com ports under the same VID/PID
     is_ultrascale = True

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -6,6 +6,7 @@ class FPGA_Board():
     uart_vid = None
     uart_pid = None
     uart_suffix = None
+    is_ultrascale = False
 
 class PYNQ_Z1(FPGA_Board):
     """
@@ -119,3 +120,4 @@ class ZCU106(FPGA_Board):
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_vid = 4292
     uart_pid = 60000
+    is_ultrascale = True

--- a/anasymod/generators/vivado.py
+++ b/anasymod/generators/vivado.py
@@ -163,13 +163,31 @@ class VivadoTCLGenerator(CodeGenerator):
         project_root = self.subst + r"\\" + self.target.prj_cfg.vivado_config.project_name
         return project_root
 
-    def run(self, filename=r"run.tcl", nolog=True, nojournal=True, interactive=False, err_str=None):
+    def run(self, filename=r"run.tcl", nolog=True, nojournal=True, stack=None,
+            interactive=False, err_str=None):
         # write the TCL script
         tcl_script = os.path.join(self.target.prj_cfg.build_root, filename)
         self.write_to_file(tcl_script)
 
         # assemble the command
-        cmd = [self.target.prj_cfg.vivado_config.vivado, '-mode', 'tcl' if interactive else 'batch', '-source', tcl_script]
+        cmd = []
+        cmd += [self.target.prj_cfg.vivado_config.vivado]
+
+        # Specify stack size if needed.  Xilinx suggests this
+        # can sometimes fix segfault issues:
+        # https://www.xilinx.com/support/answers/64434.html
+        if stack:
+            cmd += ['-stack', f'{stack}']
+
+        # run mode
+        if interactive:
+            cmd += ['-mode', 'tcl']
+        else:
+            cmd += ['-mode', 'batch']
+
+        # script location
+        cmd += ['-source', tcl_script]
+
         # inserting lsf_opts after vivado call:
         cmd[1:1] = self.target.prj_cfg.vivado_config.lsf_opts.split()
 

--- a/anasymod/generators/xsct.py
+++ b/anasymod/generators/xsct.py
@@ -13,10 +13,12 @@ class XSCTTCLGenerator(CodeGenerator):
     """
 
     def __init__(self, target: FPGATarget, xsct=None, version=None,
-                 version_year=None, version_number=None):
+                 version_year=None, version_number=None,
+                 xsct_install_dir=None):
         super().__init__()
 
         self._xsct = xsct
+        self._xsct_install_dir = xsct_install_dir
         self._version = version
         self._version_year = version_year
         self._version_number = version_number
@@ -38,6 +40,12 @@ class XSCTTCLGenerator(CodeGenerator):
         if self._xsct is None:
             self._xsct = shutil.which('xsct')
         return self._xsct
+
+    @property
+    def xsct_install_dir(self):
+        if self._xsct_install_dir is None:
+            self._xsct_install_dir = Path(self.xsct).resolve().parent.parent
+        return self._xsct_install_dir
 
     @property
     def version(self):

--- a/anasymod/structures/module_top.py
+++ b/anasymod/structures/module_top.py
@@ -48,7 +48,7 @@ class ModuleTop(JinjaTempl):
         module.add_inputs(scfg.clk_i)
         if ((target.cfg.fpga_sim_ctrl is not None) and
                 (target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ) and
-                (pcfg.board.is_ultrascale)):
+                (not pcfg.board.is_ultrascale)):
             module.add_inouts(TemplZynqGPIO.EXT_IOS)
         module.generate_header()
 
@@ -124,7 +124,7 @@ class ModuleTop(JinjaTempl):
         ## Wire through Zynq connections if needed
         if ((target.cfg.fpga_sim_ctrl is not None) and
                 (target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ) and
-                (pcfg.board.is_ultrascale)):
+                (not pcfg.board.is_ultrascale)):
             sim_ctrl_inst.add_inouts(TemplZynqGPIO.EXT_IOS,
                                      connections=TemplZynqGPIO.EXT_IOS)
 

--- a/anasymod/structures/module_top.py
+++ b/anasymod/structures/module_top.py
@@ -47,7 +47,8 @@ class ModuleTop(JinjaTempl):
         module = ModuleInst(api=self.module_ifc, name='top')
         module.add_inputs(scfg.clk_i)
         if ((target.cfg.fpga_sim_ctrl is not None) and
-                (target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ)):
+                (target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ) and
+                (pcfg.board.is_ultrascale)):
             module.add_inouts(TemplZynqGPIO.EXT_IOS)
         module.generate_header()
 
@@ -122,7 +123,8 @@ class ModuleTop(JinjaTempl):
 
         ## Wire through Zynq connections if needed
         if ((target.cfg.fpga_sim_ctrl is not None) and
-                (target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ)):
+                (target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ) and
+                (pcfg.board.is_ultrascale)):
             sim_ctrl_inst.add_inouts(TemplZynqGPIO.EXT_IOS,
                                      connections=TemplZynqGPIO.EXT_IOS)
 

--- a/anasymod/structures/module_uartsimctrl.py
+++ b/anasymod/structures/module_uartsimctrl.py
@@ -21,7 +21,7 @@ class ModuleUARTSimCtrl(JinjaTempl):
         module.add_inputs(ctrl_outputs)
         module.add_outputs(ctrl_inputs)
         module.add_input(scfg.emu_clk)
-        if scfg.is_ultrascale:
+        if not scfg.is_ultrascale:
             module.add_inouts(TemplZynqGPIO.EXT_IOS)
         module.generate_header()
 
@@ -90,7 +90,7 @@ class ModuleUARTSimCtrl(JinjaTempl):
         bd.add_output(io_obj=self.zynq_gpio.i_ctrl, connection=self.zynq_gpio.i_ctrl)
         bd.add_output(io_obj=self.zynq_gpio.i_data, connection=self.zynq_gpio.i_data)
 
-        if scfg.is_ultrascale:
+        if not scfg.is_ultrascale:
             bd.add_inouts(io_objs=TemplZynqGPIO.EXT_IOS, connections=TemplZynqGPIO.EXT_IOS)
 
         bd.generate_instantiation()

--- a/anasymod/structures/module_uartsimctrl.py
+++ b/anasymod/structures/module_uartsimctrl.py
@@ -21,7 +21,8 @@ class ModuleUARTSimCtrl(JinjaTempl):
         module.add_inputs(ctrl_outputs)
         module.add_outputs(ctrl_inputs)
         module.add_input(scfg.emu_clk)
-        module.add_inouts(TemplZynqGPIO.EXT_IOS)
+        if scfg.is_ultrascale:
+            module.add_inouts(TemplZynqGPIO.EXT_IOS)
         module.generate_header()
 
         ctrl_inputs = scfg.analog_ctrl_inputs + scfg.digital_ctrl_inputs
@@ -89,7 +90,8 @@ class ModuleUARTSimCtrl(JinjaTempl):
         bd.add_output(io_obj=self.zynq_gpio.i_ctrl, connection=self.zynq_gpio.i_ctrl)
         bd.add_output(io_obj=self.zynq_gpio.i_data, connection=self.zynq_gpio.i_data)
 
-        bd.add_inouts(io_objs=TemplZynqGPIO.EXT_IOS, connections=TemplZynqGPIO.EXT_IOS)
+        if scfg.is_ultrascale:
+            bd.add_inouts(io_objs=TemplZynqGPIO.EXT_IOS, connections=TemplZynqGPIO.EXT_IOS)
 
         bd.generate_instantiation()
 

--- a/anasymod/structures/structure_config.py
+++ b/anasymod/structures/structure_config.py
@@ -70,6 +70,9 @@ class StructureConfig():
         else:
             self.use_default_oscillator = False
 
+        # make note of whether this is an UltraScale board
+        self.is_ultrascale = prj_cfg.board.is_ultrascale
+
         #########################################################
         # Simulation control interfaces
         #########################################################

--- a/anasymod/templates/xsct_program.py
+++ b/anasymod/templates/xsct_program.py
@@ -106,6 +106,11 @@ class TemplXSCTProgram:
             self.puts('Calling psu_ps_pl_reset_config...')
             self.line('psu_ps_pl_reset_config')
             self.line('after 1000')  # TODO: is this needed?
+
+            self.puts('Magic writes... :-(')
+            self.line('mwr 0xffff0000 0x14000000')
+            self.line('mwr 0xFD1A0104 0x380E')
+            self.line('after 1000')  # TODO: is this needed?
         else:
             self.line('ps7_init')
             self.line('ps7_post_config')

--- a/anasymod/templates/xsct_program.py
+++ b/anasymod/templates/xsct_program.py
@@ -5,7 +5,8 @@
 
 class TemplXSCTProgram:
     def __init__(self, sdk_path, bit_path, hw_path, tcl_path, cpu_filter='"ARM*#0"',
-                 sw_name='sw', program_fpga=True, reset_system=True):
+                 sw_name='sw', program_fpga=True, reset_system=True,
+                 is_ultrascale=False):
 
         # initialize text
         self.text = ''
@@ -24,7 +25,7 @@ class TemplXSCTProgram:
 
         self.loadhw(hw_path)
 
-        self.init_cpu(tcl_path)
+        self.init_cpu(tcl_path=tcl_path, is_ultrascale=is_ultrascale)
 
         self.download(str(sdk_path / sw_name / 'Debug' / sw_name) + '.elf')
 
@@ -63,11 +64,15 @@ class TemplXSCTProgram:
         self.line(f'loadhw "{hw_path}"')
         self.line()
 
-    def init_cpu(self, tcl_path):
+    def init_cpu(self, tcl_path, is_ultrascale):
         self.puts('Initializing the processor...')
         self.line(f'source "{tcl_path}"')
-        self.line('ps7_init')
-        self.line('ps7_post_config')
+        if is_ultrascale:
+            self.line('psu_init')
+            self.line('psu_post_config')
+        else:
+            self.line('ps7_init')
+            self.line('ps7_post_config')
         self.line()
 
     def download(self, elf_path):

--- a/anasymod/templates/xsct_program.py
+++ b/anasymod/templates/xsct_program.py
@@ -2,34 +2,52 @@
 # 1. https://www.xilinx.com/html_docs/xilinx2018_1/SDK_Doc/xsct/use_cases/xsdb_standalone_app_debug.html
 # 2. https://github.com/Digilent/Arty-Z7-20-linux_bd/blob/master/sdk/.sdk/launch_scripts/xilinx_c-c%2B%2B_application_(system_debugger)/system_debugger_using_debug_video.elf_on_local.tcl
 # 3. https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842240/Programming+QSPI+from+U-boot+ZC702
+# 4. https://github.com/analogdevicesinc/no-OS/blob/master/scripts/xsdb.tcl
+# 5. https://www.xilinx.com/html_docs/xilinx2018_1/SDK_Doc/xsct/use_cases/xsdb_debug_app_zynqmp.html
 
 class TemplXSCTProgram:
-    def __init__(self, sdk_path, bit_path, hw_path, tcl_path, cpu_filter='"ARM*#0"',
+    def __init__(self, sdk_path, bit_path, hw_path, tcl_path,
                  sw_name='sw', program_fpga=True, reset_system=True,
-                 is_ultrascale=False):
+                 loadhw=True, init_cpu=True, download=True,
+                 run=True, connect=True, is_ultrascale=False):
 
         # initialize text
         self.text = ''
 
-        # apply commands
+        ##################
+        # apply commands #
+        ##################
 
-        self.connect()
+        # connect
+        if connect:
+            self.connect()
 
-        self.select_cpu(cpu_filter)
-
+        # reset_system
         if reset_system:
             self.reset_system()
 
+        # program_fpga
         if program_fpga:
-            self.program_fpga(bit_path)
+            self.program_fpga(bit_path=bit_path,
+                              is_ultrascale=is_ultrascale)
 
-        self.loadhw(hw_path)
+        # loadhw
+        if loadhw:
+            self.loadhw(hw_path)
 
-        self.init_cpu(tcl_path=tcl_path, is_ultrascale=is_ultrascale)
+        # init_cpu
+        if init_cpu:
+            self.init_cpu(tcl_path=tcl_path,
+                          is_ultrascale=is_ultrascale)
 
-        self.download(str(sdk_path / sw_name / 'Debug' / sw_name) + '.elf')
+        # download
+        if download:
+            self.download(elf_path=str(sdk_path / sw_name / 'Debug' / sw_name) + '.elf',
+                          is_ultrascale=is_ultrascale)
 
-        self.run()
+        # run
+        if run:
+            self.run()
 
         self.puts("Program started.")
 
@@ -39,23 +57,27 @@ class TemplXSCTProgram:
     def puts(self, s):
         self.line(f'puts "{s}"')
 
+    def set_target(self, pattern):
+        self.line(f'targets -set -filter {{name =~ "{pattern}"}}')
+
     def connect(self):
         self.puts('Connecting to the HW server...')
         self.line('connect')
         self.line()
 
-    def select_cpu(self, cpu_filter):
-        self.puts('Selecting the CPU...')
-        self.line(f'targets -set -filter {{name =~ {cpu_filter}}}')
-        self.line()
-
     def reset_system(self):
         self.puts('Resetting the system...')
+        self.set_target('APU*')
+        self.line('stop')
         self.line('rst')
         self.line()
 
-    def program_fpga(self, bit_path):
+    def program_fpga(self, bit_path, is_ultrascale):
         self.puts('Programming the FPGA...')
+        if is_ultrascale:
+            self.set_target('PSU')
+        else:
+            self.set_target('xc7z*')
         self.line(f'fpga "{bit_path}"')
         self.line()
 
@@ -66,17 +88,35 @@ class TemplXSCTProgram:
 
     def init_cpu(self, tcl_path, is_ultrascale):
         self.puts('Initializing the processor...')
+        self.set_target('APU*')
         self.line(f'source "{tcl_path}"')
         if is_ultrascale:
+            self.puts('Calling psu_init...')
             self.line('psu_init')
+            self.line('after 1000')  # TODO: is this needed?
+
+            self.puts('Calling psu_post_config...')
             self.line('psu_post_config')
+            self.line('after 1000')  # TODO: is this needed?
+
+            self.puts('Calling psu_ps_pl_isolation_removal...')
+            self.line('psu_ps_pl_isolation_removal')
+            self.line('after 1000')  # TODO: is this needed?
+
+            self.puts('Calling psu_ps_pl_reset_config...')
+            self.line('psu_ps_pl_reset_config')
+            self.line('after 1000')  # TODO: is this needed?
         else:
             self.line('ps7_init')
             self.line('ps7_post_config')
         self.line()
 
-    def download(self, elf_path):
+    def download(self, elf_path, is_ultrascale):
         self.puts('Downloading the program...')
+        if is_ultrascale:
+            self.set_target('*Cortex-A53 #0*')
+        else:
+            self.set_target('*Cortex-A9 MPCore #0*')
         self.line(f'dow "{elf_path}"')
         self.line()
 

--- a/anasymod/templates/zynq_gpio.py
+++ b/anasymod/templates/zynq_gpio.py
@@ -154,11 +154,12 @@ apply_bd_automation \\
 apply_bd_automation \\
     -rule xilinx.com:bd_rule:axi4 \\
     -config { \\
-        Clk_master {/processing_system7_0/FCLK_CLK0 (100 MHz)} \\
+        Clk_master {Auto} \\
         Clk_slave {Auto} \\
         Clk_xbar {Auto} \\
-        Master {/processing_system7_0/M_AXI_GP0} \\
+        Master {/zynq_ultra_ps_e_0/M_AXI_HPM0_FPD} \\
         Slave {/axi_gpio_1/S_AXI} \\
+        ddr_seg {Auto} \\
         intc_ip {New AXI Interconnect} \\
         master_apm {0}\\
     } \\
@@ -167,12 +168,11 @@ apply_bd_automation \\
 apply_bd_automation \\
     -rule xilinx.com:bd_rule:axi4 \\
     -config { \\
-        Clk_master {Auto} \\
+        Clk_master {/processing_system7_0/FCLK_CLK0 (100 MHz)} \\
         Clk_slave {Auto} \\
         Clk_xbar {Auto} \\
-        Master {/zynq_ultra_ps_e_0/M_AXI_HPM0_FPD} \\
+        Master {/processing_system7_0/M_AXI_GP0} \\
         Slave {/axi_gpio_1/S_AXI} \\
-        ddr_seg {Auto} \\
         intc_ip {New AXI Interconnect} \\
         master_apm {0}\\
     } \\

--- a/anasymod/templates/zynq_gpio.py
+++ b/anasymod/templates/zynq_gpio.py
@@ -1,12 +1,20 @@
+from anasymod.templates.templ import JinjaTempl
 from anasymod.sim_ctrl.datatypes import DigitalSignal
 
-class TemplZynqGPIO:
+class TemplZynqGPIO(JinjaTempl):
     def __init__(self, ps_vlnv='xilinx.com:ip:processing_system7:5.5',
-                 gpio_vlnv='xilinx.com:ip:axi_gpio:2.0', design_name='zynq_gpio'):
+                 gpio_vlnv='xilinx.com:ip:axi_gpio:2.0', design_name='zynq_gpio',
+                 ultra_ps_vlnv='xilinx.com:ip:zynq_ultra_ps_e:3.3',
+                 is_ultrascale=False):
+        # call the super constructor
+        super().__init__(trim_blocks=False, lstrip_blocks=False)
+
         # save settings
         self.design_name=design_name
         self.ps_vlnv = ps_vlnv
         self.gpio_vlnv = gpio_vlnv
+        self.ultra_ps_vlnv = ultra_ps_vlnv
+        self.is_ultrascale = is_ultrascale
 
         # save IO that are used by the emulator
         self.o_ctrl = DigitalSignal(name='o_ctrl', width=32, abspath=None)
@@ -15,36 +23,41 @@ class TemplZynqGPIO:
         self.i_data = DigitalSignal(name='i_data', width=32, abspath=None)
 
         # generate text
-        self.text = f'''
+
+    TEMPLATE_TEXT = '''\
 ############################
 # Create the block diagram #
 ############################
 
 # Initialize
 
-create_bd_design "{self.design_name}"
+create_bd_design "{{subst.design_name}}"
 
 # Instantiate IPs
 
-create_bd_cell -type ip -vlnv {self.ps_vlnv} processing_system7_0
-create_bd_cell -type ip -vlnv {self.gpio_vlnv} axi_gpio_0
-create_bd_cell -type ip -vlnv {self.gpio_vlnv} axi_gpio_1
+{% if subst.is_ultrascale %}
+create_bd_cell -type ip -vlnv {{subst.ultra_ps_vlnv}} zynq_ultra_ps_e_0
+{% else %}
+create_bd_cell -type ip -vlnv {{subst.ps_vlnv}} processing_system7_0
+{% endif %}
+create_bd_cell -type ip -vlnv {{subst.gpio_vlnv}} axi_gpio_0
+create_bd_cell -type ip -vlnv {{subst.gpio_vlnv}} axi_gpio_1
 
 # Configure IPs
 
 set_property \\
     -dict [list \\
-        CONFIG.C_IS_DUAL {{1}} \\
-        CONFIG.C_ALL_OUTPUTS {{1}} \\
-        CONFIG.C_ALL_INPUTS_2 {{1}} \\
+        CONFIG.C_IS_DUAL {1} \\
+        CONFIG.C_ALL_OUTPUTS {1} \\
+        CONFIG.C_ALL_INPUTS_2 {1} \\
     ] \\
     [get_bd_cells axi_gpio_0]
 
 set_property \\
     -dict [list \\
-        CONFIG.C_IS_DUAL {{1}} \\
-        CONFIG.C_ALL_OUTPUTS {{1}} \\
-        CONFIG.C_ALL_OUTPUTS_2 {{1}} \\
+        CONFIG.C_IS_DUAL {1} \\
+        CONFIG.C_ALL_OUTPUTS {1} \\
+        CONFIG.C_ALL_OUTPUTS_2 {1} \\
     ] \\
     [get_bd_cells axi_gpio_1]
 
@@ -57,9 +70,11 @@ create_bd_port -dir O -from 31 -to 0 i_data
 
 # Wire up IPs
 
+{% if not subst.is_ultrascale %}
 connect_bd_net \\
     [get_bd_pins processing_system7_0/FCLK_CLK0] \\
     [get_bd_pins processing_system7_0/M_AXI_GP0_ACLK]
+{% endif %}
 
 connect_bd_net \\
     [get_bd_ports o_ctrl] \\
@@ -77,43 +92,110 @@ connect_bd_net \\
     [get_bd_ports i_data] \\
     [get_bd_pins axi_gpio_1/gpio2_io_o]
 
-# Apply automation    
+####################
+# Apply automation #
+####################   
 
+# processing system automation
+
+{% if subst.is_ultrascale %}
+apply_bd_automation \\
+    -rule xilinx.com:bd_rule:zynq_ultra_ps_e \\
+    -config { \\
+        apply_board_preset "1" \\
+    } \\
+    [get_bd_cells zynq_ultra_ps_e_0]
+{% else %}
 apply_bd_automation \\
     -rule xilinx.com:bd_rule:processing_system7 \\
-    -config {{ \\
+    -config { \\
         make_external "FIXED_IO, DDR" \\
         apply_board_preset "1" \\
         Master "Disable" \\
         Slave "Disable" \\
-    }} \\
+    } \\
     [get_bd_cells processing_system7_0]
+{% endif %}
 
+# axi_gpio_0 automation
+
+{% if subst.is_ultrascale %}
 apply_bd_automation \\
     -rule xilinx.com:bd_rule:axi4 \\
-    -config {{ \\
-        Clk_master {{/processing_system7_0/FCLK_CLK0 (100 MHz)}} \\
-        Clk_slave {{Auto}} \\
-        Clk_xbar {{Auto}} \\
-        Master {{/processing_system7_0/M_AXI_GP0}} \\
-        Slave {{/axi_gpio_0/S_AXI}} \\
-        intc_ip {{New AXI Interconnect}} \\
-        master_apm {{0}}\\
-    }} \\
+    -config { \\
+        Clk_master {Auto} \\
+        Clk_slave {Auto} \\
+        Clk_xbar {Auto} \\
+        Master {/zynq_ultra_ps_e_0/M_AXI_HPM0_FPD} \\
+        Slave {/axi_gpio_0/S_AXI} \\
+        ddr_seg {Auto} \\
+        intc_ip {New AXI Interconnect} \\
+        master_apm {0}\\
+    } \\
     [get_bd_intf_pins axi_gpio_0/S_AXI]
-
+{% else %}
 apply_bd_automation \\
     -rule xilinx.com:bd_rule:axi4 \\
-    -config {{ \\
-        Clk_master {{/processing_system7_0/FCLK_CLK0 (100 MHz)}} \\
-        Clk_slave {{Auto}} \\
-        Clk_xbar {{Auto}} \\
-        Master {{/processing_system7_0/M_AXI_GP0}} \\
-        Slave {{/axi_gpio_1/S_AXI}} \\
-        intc_ip {{New AXI Interconnect}} \\
-        master_apm {{0}}\\
-    }} \\
+    -config { \\
+        Clk_master {/processing_system7_0/FCLK_CLK0 (100 MHz)} \\
+        Clk_slave {Auto} \\
+        Clk_xbar {Auto} \\
+        Master {/processing_system7_0/M_AXI_GP0} \\
+        Slave {/axi_gpio_0/S_AXI} \\
+        intc_ip {New AXI Interconnect} \\
+        master_apm {0}\\
+    } \\
+    [get_bd_intf_pins axi_gpio_0/S_AXI]
+{% endif %}
+
+# axi_gpio_1 automation
+
+{% if subst.is_ultrascale %}
+apply_bd_automation \\
+    -rule xilinx.com:bd_rule:axi4 \\
+    -config { \\
+        Clk_master {/processing_system7_0/FCLK_CLK0 (100 MHz)} \\
+        Clk_slave {Auto} \\
+        Clk_xbar {Auto} \\
+        Master {/processing_system7_0/M_AXI_GP0} \\
+        Slave {/axi_gpio_1/S_AXI} \\
+        intc_ip {New AXI Interconnect} \\
+        master_apm {0}\\
+    } \\
     [get_bd_intf_pins axi_gpio_1/S_AXI]
+{% else %}
+apply_bd_automation \\
+    -rule xilinx.com:bd_rule:axi4 \\
+    -config { \\
+        Clk_master {Auto} \\
+        Clk_slave {Auto} \\
+        Clk_xbar {Auto} \\
+        Master {/zynq_ultra_ps_e_0/M_AXI_HPM0_FPD} \\
+        Slave {/axi_gpio_1/S_AXI} \\
+        ddr_seg {Auto} \\
+        intc_ip {New AXI Interconnect} \\
+        master_apm {0}\\
+    } \\
+    [get_bd_intf_pins axi_gpio_1/S_AXI]
+{% endif %}
+
+# other automation
+
+{% if subst.is_ultrascale %}
+apply_bd_automation \\
+    -rule xilinx.com:bd_rule:axi4 \\
+    -config { \\
+        Clk_master {Auto} \\
+        Clk_slave {/zynq_ultra_ps_e_0/pl_clk0 (99 MHz)} \\
+        Clk_xbar {/zynq_ultra_ps_e_0/pl_clk0 (99 MHz)} \\
+        Master {/zynq_ultra_ps_e_0/M_AXI_HPM1_FPD} \\
+        Slave {/axi_gpio_0/S_AXI} \\
+        ddr_seg {Auto} \\
+        intc_ip {/ps8_0_axi_periph} \\
+        master_apm {0}\\
+    } \\
+    [get_bd_intf_pins zynq_ultra_ps_e_0/M_AXI_HPM1_FPD]
+{% endif %}
 
 validate_bd_design
 '''

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev1'
+version = '0.3.5.dev2'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev5'
+version = '0.3.5.dev6'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.4'
+version = '0.3.5.dev1'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev7'
+version = '0.3.5'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev4'
+version = '0.3.5.dev5'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev6'
+version = '0.3.5.dev7'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev3'
+version = '0.3.5.dev4'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.5.dev2'
+version = '0.3.5.dev3'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/unittests/firmware/main.c
+++ b/unittests/firmware/main.c
@@ -8,11 +8,13 @@
 #define SET_MODE 3
 #define GET_C 4
 
+#define BUF_SIZE 32
+
 int main() {
     // character buffering
     u32 idx = 0;
     char rcv;
-    char buf [32];
+    char buf [BUF_SIZE];
     
     // command processing;
     u32 cmd;
@@ -29,7 +31,12 @@ int main() {
         if ((rcv == ' ') || (rcv == '\t') || (rcv == '\r') || (rcv == '\n')) {
             // whitespace
             if (idx > 0) {
-                buf[idx++] = '\0';
+                // pad rest of the string with null characters
+                // this appears to be necessary to prevent
+                // memory corruption
+                for (; idx<BUF_SIZE; idx++) {
+                    buf[idx] = '\0';
+                }
                 if (nargs == 0) {
                     if (strcmp(buf, "HELLO") == 0) {
                         xil_printf("Hello World!\r\n");
@@ -46,13 +53,13 @@ int main() {
                         cmd = SET_MODE;
                         nargs++;
                     } else if (strcmp(buf, "GET_C") == 0) {
-                        xil_printf("%0d\r\n", get_c_out());
+                        xil_printf("%u\r\n", get_c_out());
                         nargs = 0;
                     } else {
 	                    xil_printf("ERROR: Unknown command\r\n");
                     }
                 } else if (nargs == 1) {
-                    sscanf(buf, "%lu", &arg1);
+                    sscanf(buf, "%u", &arg1);
                     if (cmd == SET_A) {
                         set_a_in(arg1);
                     } else if (cmd == SET_B) {


### PR DESCRIPTION
## Summary
This PR adds support for the ZCU106 board.  This turned out to be a bit involved, not only because it is the first UltraScale+ board that we have looked at, but also because it has an unusual problem with the DDR4 chips used on the board.

## Details
* FPGA board definitions now have an optional ``is_ultrascale`` property (defaults to ``False``)
* The PS block diagram generator is updated to support the UltraScale+ PS, which looks a bit different than the Zynq PS.
* When the UltraScale+ PS is used, the external I/Os should not be routed through to the top level RTL, so that detail is taken care of as well.
* The XSCT programming template is updated so that it uses the FSBL flow for UltraScale+ boards, and the TCL flow for other boards.  This is required for ZCU106, since it only works with the FSBL flow (more information [here](https://www.xilinx.com/support/answers/72210.html))
* Added an optional ``vivado_stack`` setting to the ``prj.yaml`` file.  For UltraScale+ designs, sometimes it is necessary to set this to ``2000`` to prevent Vivado from freezing.  It might just be an issue on older computers like mine, though.