### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![BuildKite status](https://badge.buildkite.com/7f10348afca3b631bbbb2175919b9039101c2a5e55c3371460.svg?branch=master)](https://buildkite.com/stanford-aha/anasymod)
 [![Code Coverage](https://codecov.io/gh/sgherbst/anasymod/branch/master/graph/badge.svg)](https://codecov.io/gh/sgherbst/anasymod)
 [![License:BSD-3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![Join the chat at https://gitter.im/sgherbst/anasymod](https://badges.gitter.im/sgherbst/anasymod.svg)](https://gitter.im/sgherbst/anasymod?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 **anasymod** is a tool for running FPGA emulations of mixed-signal systems.  It supports digital blocks described with Verilog or VHDL and synthesizable analog models created using [msdsl](https://github.com/sgherbst/msdsl) and [svreal](https://github.com/sgherbst/svreal).
 

--- a/anasymod/analysis.py
+++ b/anasymod/analysis.py
@@ -1,4 +1,4 @@
-import shutil, zipfile, filecmp, errno
+import shutil, zipfile, filecmp, errno, time
 import os.path
 import yaml
 import numpy as np
@@ -330,8 +330,11 @@ class Analysis():
 
         VivadoEmulation(target=target).build()
 
-        # Build firmware for ctrl infrastructure if needed
+        # Build firmware for ctrl infrastructure if needed, first
+        # waiting a short time for outputs from Vivado to sync
+        # to disk.  This seems to be an issue with NFS.
         if target.cfg.fpga_sim_ctrl == FPGASimCtrl.UART_ZYNQ:
+            time.sleep(1)
             self._build_firmware(*args, **kwargs)
 
         statpro.statpro_update(statpro.FEATURES.anasymod_build_vivado)

--- a/anasymod/emu/xsct_emu.py
+++ b/anasymod/emu/xsct_emu.py
@@ -105,6 +105,7 @@ class XSCTEmulation(XSCTTCLGenerator):
                 tcl_path=self.tcl_path,
                 is_ultrascale=self.pcfg.board.is_ultrascale,
                 xsct_install_dir=self.pcfg.xsct_config.xsct_install_dir,
+                no_rev_check=self.pcfg.board.no_rev_check,
                 pcfg=self.pcfg,
                 **kwargs
             ).text

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -104,7 +104,7 @@ class ULTRA96(FPGA_Board):
     clk_freq = 26e6
     full_part_name = 'xczu3eg-sbva484-???'
     short_part_name = 'xczu3eg'
-    bram = None
+    bram = 7.6e6
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_zynq_vid = [1027] # might need adjustment
     uart_zynq_pid = [24592] # might need adjustment
@@ -135,6 +135,7 @@ class ZCU102(FPGA_Board):
     board_part = 'xilinx.com:zcu102:part0:3.3'
     full_part_name = 'xczu9eg-ffvb1156-2-e'
     short_part_name = 'xczu9eg'
+    bram = 32.1e6
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_zynq_vid = [4292]
     uart_zynq_pid = [60017]
@@ -151,6 +152,7 @@ class ZCU106(FPGA_Board):
     board_part = 'xilinx.com:zcu106:part0:2.5'
     full_part_name = 'xczu7ev-ffvc1156-2-e'
     short_part_name = 'xczu7ev'
+    bram = 11.0e6
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_zynq_vid = [4292]
     uart_zynq_pid = [60017]

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -7,6 +7,7 @@ class FPGA_Board():
     uart_pid = None
     uart_suffix = None
     is_ultrascale = False
+    no_rev_check = False
 
 class PYNQ_Z1(FPGA_Board):
     """
@@ -132,15 +133,16 @@ class ZCU102(FPGA_Board):
     clk_pin = ['AL8', 'AL7']
     clk_io = 'DIFF_SSTL12'
     clk_freq = 300e6
-    board_part = 'xilinx.com:zcu102:part0:3.3'
+    board_part = 'xilinx.com:zcu102:part0:3.2'
     full_part_name = 'xczu9eg-ffvb1156-2-e'
-    short_part_name = 'xczu9eg'
+    short_part_name = 'xczu9'
     bram = 32.1e6
     fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
     uart_zynq_vid = [4292]
     uart_zynq_pid = [60017]
     uart_suffix = '.0'  # needed since this board has four com ports under the same VID/PID
     is_ultrascale = True
+    no_rev_check = True  # needed in case the FPGA is an engineering sample
 
 class ZCU106(FPGA_Board):
     """

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -129,9 +129,9 @@ class ZCU102(FPGA_Board):
     """
     Container to store ZCU102 FPGA board specific properties.
     """
-    clk_pin = ['G21', 'F21']
-    clk_io = 'LVDS_25'
-    clk_freq = 125e6
+    clk_pin = ['AL8', 'AL7']
+    clk_io = 'DIFF_SSTL12'
+    clk_freq = 300e6
     board_part = 'xilinx.com:zcu102:part0:3.3'
     full_part_name = 'xczu9eg-ffvb1156-2-e'
     short_part_name = 'xczu9eg'

--- a/anasymod/sim_ctrl/uart_zynq_ctrlapi.py
+++ b/anasymod/sim_ctrl/uart_zynq_ctrlapi.py
@@ -62,6 +62,8 @@ class UARTCtrlApi(CtrlApi):
         else:
             self.pid_list = [pid]
 
+        self.uart_suffix = self.pcfg.board.uart_suffix
+
         self.port_list = []
     ### User Functions
 
@@ -325,7 +327,8 @@ class UARTCtrlApi(CtrlApi):
             # check if any COM port is compliant to known vids and pids and if so store the device_id
             for port in comports:
                 if ((port.vid in self.vid_list) and (port.pid in self.pid_list)):
-                    self.port_list.append(port.device)
+                    if (self.uart_suffix is None) or (port.location.endswith(self.uart_suffix)):
+                        self.port_list.append(port.device)
 
             for port in self.port_list:
                 try:

--- a/anasymod/templates/launch_FPGA_sim.py
+++ b/anasymod/templates/launch_FPGA_sim.py
@@ -21,8 +21,9 @@ class TemplLAUNCH_FPGA_SIM(JinjaTempl):
         # are problems with the debug hub clock
         self.jtag_freq = str(int(pcfg.cfg.jtag_freq))
 
-        # set the "short" device name which is used to distinguish the FPGA part from other USB devices
+        # save some parameters from the board configuration
         self.device_name = pcfg.board.short_part_name
+        self.no_rev_check = pcfg.board.no_rev_check
 
         # Set aliases for VIOs
         self.ctrl_io_aliases = SVAPI()
@@ -71,6 +72,13 @@ connect_hw_server -url {{subst.server_addr}}
 {% endif %}
 set_property PARAM.FREQUENCY {{subst.jtag_freq}} [get_hw_targets]
 open_hw_target
+
+{% if subst.no_rev_check %}
+# Don't check revision compatibility between the bitstream
+# and FPGA.  This is needed for some boards that use
+# engineering samples.
+set_param xicom.use_bitstream_version_check false 
+{% endif %}
 
 # Configure files to be programmed
 set my_hw_device [get_hw_devices {{subst.device_name}}*]

--- a/anasymod/templates/xsct_program.py
+++ b/anasymod/templates/xsct_program.py
@@ -14,7 +14,8 @@ class TemplXSCTProgram:
                  sw_name='sw', program_fpga=True, reset_system=True,
                  loadhw=True, init_cpu=True, download=True,
                  run=True, connect=True, is_ultrascale=False,
-                 xsct_install_dir=None, server_addr=None):
+                 xsct_install_dir=None, no_rev_check=False,
+                 server_addr=None):
 
         # save settings
         self.sdk_path = sdk_path
@@ -24,6 +25,7 @@ class TemplXSCTProgram:
         self.sw_name = sw_name
         self.is_ultrascale = is_ultrascale
         self.xsct_install_dir = xsct_install_dir
+        self.no_rev_check = no_rev_check
         self.pcfg  = pcfg
 
         # initialize text
@@ -42,7 +44,7 @@ class TemplXSCTProgram:
             self.puts('Load utility functions for Zynq MP.')
             zynqmp_utils_tcl = (Path(self.xsct_install_dir) / 'scripts' /
                                 'vitis' / 'util' / 'zynqmp_utils.tcl')
-            self.line(f'source "{zynqmp_utils_tcl}"')
+            self.line(f'source "{zynqmp_utils_tcl.as_posix()}"')
             self.line()
 
         # reset_system
@@ -118,7 +120,12 @@ class TemplXSCTProgram:
             self.set_target('PSU')
         else:
             self.set_target('xc7z*')
-        self.line(f'fpga "{self.bit_path.as_posix()}"')
+        cmd = []
+        cmd += ['fpga']
+        cmd += ['-f', f'"{self.bit_path.as_posix()}"']
+        if self.no_rev_check:
+            cmd += ['-no-revision-check']
+        self.line(' '.join(cmd))
         self.line()
 
     def loadhw(self, hw_path):
@@ -151,7 +158,7 @@ class TemplXSCTProgram:
             # download the FSBL ELF is located
             fsbl_path = (Path(self.sdk_path) / 'top' / 'export' / 'top' /
                          'sw' / 'top' / 'boot' / 'fsbl.elf')
-            self.line(f'dow "{fsbl_path}"')
+            self.line(f'dow "{fsbl_path.as_posix()}"')
             # wait for FSBL to finish running
             self.line('set bp_0_6_fsbl_bp [bpadd -addr &XFsbl_Exit]')
             self.line('con -block -timeout 60')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.6.dev3'
+version = '0.3.6.dev4'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\
@@ -12,13 +12,13 @@ with open('README.md', 'r') as fh:
     LONG_DESCRIPTION = fh.read()
 
 install_requires=[
-        'svreal>=0.2.2',
-        'msdsl>=0.3.6.dev1',
-        'jinja2',
-        'pyvcd',
-        'pyserial',
-        'PyYAML',
-        'si-prefix'
+    'svreal>=0.2.7',
+    'msdsl>=0.3.6.dev2',
+    'jinja2',
+    'pyvcd',
+    'pyserial',
+    'PyYAML',
+    'si-prefix'
 ]
 if os.name == 'nt':
     install_requires += ['wexpect>=3.3.0']

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.6.dev2'
+version = '0.3.6.dev3'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.7'
+version = '0.3.8'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.6'
+version = '0.3.7'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.6.dev4'
+version = '0.3.6'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 
 install_requires=[
     'svreal>=0.2.7',
-    'msdsl>=0.3.6.dev2',
+    'msdsl>=0.3.6',
     'jinja2',
     'pyvcd',
     'pyserial',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 
 install_requires=[
         'svreal>=0.2.2',
-        'msdsl>=0.3.5',
+        'msdsl>=0.3.6.dev1',
         'jinja2',
         'pyvcd',
         'pyserial',

--- a/unittests/multi_clock/clks.yaml
+++ b/unittests/multi_clock/clks.yaml
@@ -7,9 +7,6 @@ derived_clks:
     abspath: 'tb_i'
     gated_clk_req: 'clk_val_1'
     gated_clk: 'clk_1'
-  tb_emu_dt:
-    abspath: 'tb_i'
-    emu_dt: 'emu_dt'
   osc_0:
     abspath: 'tb_i.osc_0'
     emu_clk: 'emu_clk'

--- a/unittests/multi_clock/gen.py
+++ b/unittests/multi_clock/gen.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from argparse import ArgumentParser
-from msdsl import MixedSignalModel, VerilogGenerator, clamp_op, to_uint
+from msdsl import MixedSignalModel, VerilogGenerator
 from msdsl.expr.extras import if_
 
 def main():
@@ -38,8 +38,7 @@ def main():
 
     # determine the next period
     m.bind_name('dt_req_imm', if_(m.req_grant, m.dt_req_next, m.dt_req_incr))
-    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<31)-1), width=32))  # TODO: cleanup
-    m.set_next_cycle(m.dt_req, m.dt_req_clamped, clk=m.emu_clk, rst=m.emu_rst)
+    m.set_next_cycle(m.dt_req, m.dt_req_imm, clk=m.emu_clk, rst=m.emu_rst, check_format=False)
 
     # determine the output filename
     filename = Path(a.output).resolve() / f'{m.module_name}.sv'

--- a/unittests/multi_clock/gen.py
+++ b/unittests/multi_clock/gen.py
@@ -38,7 +38,7 @@ def main():
 
     # determine the next period
     m.bind_name('dt_req_imm', if_(m.req_grant, m.dt_req_next, m.dt_req_incr))
-    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<32)-1)))  # TODO: cleanup
+    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<31)-1), width=32))  # TODO: cleanup
     m.set_next_cycle(m.dt_req, m.dt_req_clamped, clk=m.emu_clk, rst=m.emu_rst)
 
     # determine the output filename

--- a/unittests/multi_clock/gen.py
+++ b/unittests/multi_clock/gen.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from argparse import ArgumentParser
-from msdsl import MixedSignalModel, VerilogGenerator
+from msdsl import MixedSignalModel, VerilogGenerator, clamp_op, to_uint
 from msdsl.expr.extras import if_
 
 def main():
@@ -18,7 +18,6 @@ def main():
     m.add_digital_input('emu_rst')
     m.add_digital_output('dt_req', 32)
     m.add_digital_input('emu_dt', 32)
-    m.add_digital_input('neg_emu_dt', 32)  # TODO: cleanup
     m.add_digital_output('clk_val')
     m.add_digital_input('t_lo', 32)
     m.add_digital_input('t_hi', 32)
@@ -35,11 +34,12 @@ def main():
     m.bind_name('dt_req_next', if_(m.prev_clk_val, m.t_lo, m.t_hi))
 
     # increment the time request
-    m.bind_name('dt_req_incr', m.dt_req + m.neg_emu_dt)
+    m.bind_name('dt_req_incr', m.dt_req - m.emu_dt)
 
     # determine the next period
     m.bind_name('dt_req_imm', if_(m.req_grant, m.dt_req_next, m.dt_req_incr))
-    m.set_next_cycle(m.dt_req, m.dt_req_imm[31:0], clk=m.emu_clk, rst=m.emu_rst)
+    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<32)-1)))  # TODO: cleanup
+    m.set_next_cycle(m.dt_req, m.dt_req_clamped, clk=m.emu_clk, rst=m.emu_rst)
 
     # determine the output filename
     filename = Path(a.output).resolve() / f'{m.module_name}.sv'

--- a/unittests/multi_clock/tb.sv
+++ b/unittests/multi_clock/tb.sv
@@ -4,14 +4,8 @@ module tb;
     (* dont_touch = "true" *) logic clk_val_1;
     (* dont_touch = "true" *) logic clk_0;
     (* dont_touch = "true" *) logic clk_1;
-    (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] emu_dt;
-
-    // negate emu_dt
-    // TODO: fix this (related to https://github.com/sgherbst/msdsl/issues/20)
-    logic [((`DT_WIDTH)-1):0] neg_emu_dt;
-    assign neg_emu_dt = -emu_dt;
 
     // oscillators
-    osc osc_0 (.clk_val(clk_val_0), .neg_emu_dt(neg_emu_dt));
-    osc osc_1 (.clk_val(clk_val_1), .neg_emu_dt(neg_emu_dt));
+    osc osc_0 (.clk_val(clk_val_0));
+    osc osc_1 (.clk_val(clk_val_1));
 endmodule

--- a/unittests/one_clock/gen.py
+++ b/unittests/one_clock/gen.py
@@ -38,8 +38,7 @@ def main():
 
     # determine the next period
     m.bind_name('dt_req_imm', if_(m.req_grant, m.dt_req_next, m.dt_req_incr))
-    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<31)-1), width=32))  # TODO: cleanup
-    m.set_next_cycle(m.dt_req, m.dt_req_clamped, clk=m.emu_clk, rst=m.emu_rst)
+    m.set_next_cycle(m.dt_req, m.dt_req_imm, clk=m.emu_clk, rst=m.emu_rst, check_format=False)
 
     # determine the output filename
     filename = Path(a.output).resolve() / f'{m.module_name}.sv'

--- a/unittests/one_clock/gen.py
+++ b/unittests/one_clock/gen.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from argparse import ArgumentParser
-from msdsl import MixedSignalModel, VerilogGenerator, to_uint, clamp_op
+from msdsl import MixedSignalModel, VerilogGenerator
 from msdsl.expr.extras import if_
 
 def main():

--- a/unittests/one_clock/gen.py
+++ b/unittests/one_clock/gen.py
@@ -38,7 +38,7 @@ def main():
 
     # determine the next period
     m.bind_name('dt_req_imm', if_(m.req_grant, m.dt_req_next, m.dt_req_incr))
-    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<32)-1)))  # TODO: cleanup
+    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<31)-1), width=32))  # TODO: cleanup
     m.set_next_cycle(m.dt_req, m.dt_req_clamped, clk=m.emu_clk, rst=m.emu_rst)
 
     # determine the output filename

--- a/unittests/one_clock/gen.py
+++ b/unittests/one_clock/gen.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from argparse import ArgumentParser
-from msdsl import MixedSignalModel, VerilogGenerator
+from msdsl import MixedSignalModel, VerilogGenerator, to_uint, clamp_op
 from msdsl.expr.extras import if_
 
 def main():
@@ -18,7 +18,6 @@ def main():
     m.add_digital_input('emu_rst')
     m.add_digital_output('dt_req', 32)
     m.add_digital_input('emu_dt', 32)
-    m.add_digital_input('neg_emu_dt', 32)  # TODO: cleanup
     m.add_digital_output('clk_val')
     m.add_digital_input('t_lo', 32)
     m.add_digital_input('t_hi', 32)
@@ -35,11 +34,12 @@ def main():
     m.bind_name('dt_req_next', if_(m.prev_clk_val, m.t_lo, m.t_hi))
 
     # increment the time request
-    m.bind_name('dt_req_incr', m.dt_req + m.neg_emu_dt)
+    m.bind_name('dt_req_incr', m.dt_req - m.emu_dt)
 
     # determine the next period
     m.bind_name('dt_req_imm', if_(m.req_grant, m.dt_req_next, m.dt_req_incr))
-    m.set_next_cycle(m.dt_req, m.dt_req_imm[31:0], clk=m.emu_clk, rst=m.emu_rst)
+    m.bind_name('dt_req_clamped', to_uint(clamp_op(m.dt_req_imm, 0, (1<<32)-1)))  # TODO: cleanup
+    m.set_next_cycle(m.dt_req, m.dt_req_clamped, clk=m.emu_clk, rst=m.emu_rst)
 
     # determine the output filename
     filename = Path(a.output).resolve() / f'{m.module_name}.sv'

--- a/unittests/one_clock/tb.sv
+++ b/unittests/one_clock/tb.sv
@@ -11,18 +11,12 @@ module tb;
     (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] t_lo;
     (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] t_hi;
 
-    // negate emu_dt
-    // TODO: fix this (related to https://github.com/sgherbst/msdsl/issues/20)
-    logic [((`DT_WIDTH)-1):0] neg_emu_dt;
-    assign neg_emu_dt = -emu_dt;
-
     // oscillator
     osc osc_i (
         .emu_clk(emu_clk),
         .emu_rst(emu_rst),
         .dt_req(dt_req),
         .emu_dt(emu_dt),
-        .neg_emu_dt(neg_emu_dt),
         .clk_val(clk_val),
         .t_lo(t_lo),
         .t_hi(t_hi)


### PR DESCRIPTION
This PR addresses two minor issues:
1. Added missing BRAM information for a couple of boards (Vivado builds for those boards were failing without it).
2. Cleaned up ``one_cycle`` and ``multi_cycle`` tests so that they don't need to pass in a negated version of the emulator timestep.