### PR TITLE
Fix cvxpy issue

### DIFF
--- a/regress.sh
+++ b/regress.sh
@@ -8,6 +8,7 @@ pip install wheel
 pip install "pytest<5" pytest-cov
 
 # temporary fix
+pip install numpy
 pip install cvxpy==1.1.7
 
 # install anasymod

--- a/regress.sh
+++ b/regress.sh
@@ -7,6 +7,9 @@ python -m pip install --upgrade pip
 pip install wheel
 pip install "pytest<5" pytest-cov
 
+# temporary fix
+pip install cvxpy==1.1.7
+
 # install anasymod
 pip install -e .
 


### PR DESCRIPTION
There is a problem installing the latest version of cvxpy (https://github.com/cvxgrp/cvxpy/issues/1229), so this pins the cvxpy version for the regression test.