### PR TITLE
Add AFE example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.log
 *.str
 *.egg-info
+*.s4p
 __pycache__
 build
 dist/

--- a/anasymod/verilog/anasymod.sv
+++ b/anasymod/verilog/anasymod.sv
@@ -31,3 +31,11 @@ task sleep_emu(input real t);
         wait_emu_cycle();
     end
 endtask
+
+task set_max_emu_dt(input real t);
+    longint tgt;
+    tgt = longint'(t/(`DT_SCALE));
+
+    force top.sim_ctrl_gen_i.emu_ctrl_data_state = tgt;
+    force top.sim_ctrl_gen_i.emu_ctrl_mode_state = 3;
+endtask

--- a/examples/afe/.gitignore
+++ b/examples/afe/.gitignore
@@ -1,0 +1,1 @@
+simctrl.yaml

--- a/examples/afe/clks.yaml
+++ b/examples/afe/clks.yaml
@@ -1,0 +1,10 @@
+derived_clks:
+  tb_emu_io:
+    abspath: 'tb_i'
+    emu_clk: 'emu_clk'
+    emu_rst: 'emu_rst'
+    emu_dt: 'emu_dt'
+    dt_req: 'dt_req'
+#  ext_dt:
+#    abspath: 'tb_i'
+#    dt_req: 'ext_dt'

--- a/examples/afe/prj.yaml
+++ b/examples/afe/prj.yaml
@@ -6,5 +6,5 @@ PROJECT:
   flatten_hierarchy': 'none'
   vivado_stack: 2000
   ila_depth: 1024
-#  cpu_debug_mode: 1
-#  cpu_debug_hierarchies: [[0, "top.tb_i"]]
+# cpu_debug_mode: 1
+# cpu_debug_hierarchies: [[0, "top"]]

--- a/examples/afe/prj.yaml
+++ b/examples/afe/prj.yaml
@@ -5,6 +5,6 @@ PROJECT:
   emu_clk_freq: 10e6
   flatten_hierarchy': 'none'
   vivado_stack: 2000
-  ila_depth: 1024
+  ila_depth: 4096
 # cpu_debug_mode: 1
 # cpu_debug_hierarchies: [[0, "top"]]

--- a/examples/afe/prj.yaml
+++ b/examples/afe/prj.yaml
@@ -1,0 +1,10 @@
+PROJECT:
+  dt: 0.1e-6
+  board_name: ZC706
+  plugins: ['msdsl']
+  emu_clk_freq: 10e6
+  flatten_hierarchy': 'none'
+  vivado_stack: 2000
+  ila_depth: 1024
+#  cpu_debug_mode: 1
+#  cpu_debug_hierarchies: [[0, "top.tb_i"]]

--- a/examples/afe/run.py
+++ b/examples/afe/run.py
@@ -23,7 +23,7 @@ THIS_DIR = Path(__file__).resolve().parent
 BUILD_DIR = THIS_DIR / 'build'
 TOP_DIR = THIS_DIR.parent.parent
 
-def run_target(target, interactive=False, debug=False):
+def run_target(target, interactive=True, debug=False):
     if target.startswith('models'):
         create_models()
     elif target.startswith('sim'):

--- a/examples/afe/run.py
+++ b/examples/afe/run.py
@@ -1,0 +1,134 @@
+# general imports
+import yaml
+import numpy as np
+from math import floor
+from scipy.interpolate import interp1d
+from pathlib import Path
+from argparse import ArgumentParser
+
+# msdsl imports
+from msdsl import VerilogGenerator
+from svreal import RealType
+from msdsl.templates.lds import CTLEModel
+from msdsl.templates.saturation import SaturationModel
+from msdsl.templates.channel import ChannelModel
+from msdsl.rf import s4p_to_step
+from msdsl.templates.uniform import UniformRandom
+from msdsl.templates.oscillator import OscillatorModel
+
+# anasymod imports
+from anasymod.analysis import Analysis
+
+THIS_DIR = Path(__file__).resolve().parent
+BUILD_DIR = THIS_DIR / 'build'
+TOP_DIR = THIS_DIR.parent.parent
+
+def run_target(target, interactive=False, debug=False):
+    if target.startswith('models'):
+        create_models()
+    elif target.startswith('sim'):
+        simulator = target.split('_')[1]
+        ana = setup_target('sim', simulator=simulator)
+        ana.simulate()
+    elif target.startswith('build'):
+        ana = setup_target('fpga', synthesizer='vivado')
+        ana.build()
+    elif target.startswith('emulate'):
+        ana = setup_target('fpga', synthesizer='vivado')
+        if interactive:
+            return ana.launch(debug=debug)
+        else:
+            ana.emulate()
+    else:
+        raise Exception(f'Unsupported target: {target}')
+
+
+def setup_target(target, simulator=None, synthesizer=None, viewer=None):
+    ana = Analysis(input=str(THIS_DIR), build_root=str(BUILD_DIR),
+                   simulator_name=simulator, synthesizer_name=synthesizer,
+                   viewer_name=viewer)
+    (BUILD_DIR / 'models').mkdir(exist_ok=True, parents=True)
+    ana.set_target(target_name=target)
+    return ana
+
+
+def create_models(ui=62.5e-12, gbw=40e9, npts=4, func_numel=512, dt_width=32, dt_scale=1e-15,
+                  real_type=RealType.FixedPoint):
+    print('Running model generator...')
+
+    # generate channel step response
+    t_orig, v_orig = s4p_to_step(TOP_DIR / 'peters_01_0605_B1_thru.s4p', dt=0.1e-12, T=10e-9)
+    t_step = np.linspace(2e-9, 6e-9, func_numel)
+    v_step = interp1d(t_orig, v_orig)(t_step)
+    t_step -= t_step[0]
+
+    # calculate number of terms needed for memory
+    t_dur = t_step[-1] - t_step[0]
+    num_terms = int(round(0.6 * t_dur/ui))
+    print(f'num_terms: {num_terms}')
+
+    # list of all modules to be generated
+    models = [
+        ('unfm', UniformRandom, dict(real_type=real_type)),
+        ('osc', OscillatorModel, dict(
+            dt_width=dt_width, dt_scale=dt_scale, init=int(floor(ui/dt_scale)), real_type=real_type)),
+        ('ctle1', CTLEModel, dict(fz=0.8e9, fp1=1.6e9, gbw=gbw, num_spline=npts, dtmax=ui, real_type=real_type)),
+        ('ctle2', CTLEModel, dict(fz=3.5e9, fp1=7e9, gbw=gbw, num_spline=npts, dtmax=ui, real_type=real_type)),
+        ('ctle3', CTLEModel, dict(fz=5e9, fp1=10e9, gbw=gbw, num_spline=npts, dtmax=ui, real_type=real_type)),
+        ('nonlin', SaturationModel, dict(compr=-1, units='dB', veval=1.0, numel=64, real_type=real_type)),
+        ('channel', ChannelModel, dict(t_step=t_step, v_step=v_step, dtmax=ui, num_spline=npts, num_terms=num_terms,
+                                       func_order=1, func_numel=func_numel, real_type=real_type))
+    ]
+
+    # generate modules
+    for module_name, module_cls, module_kwargs in models:
+        print(f'Building model: {module_name}')
+        build_dir = BUILD_DIR / module_name
+        build_dir.mkdir(exist_ok=True, parents=True)
+        model = module_cls(**module_kwargs, module_name=module_name, build_dir=build_dir, clk='emu_clk', rst='emu_rst')
+        model.compile_to_file(VerilogGenerator())
+
+    # generate simctrl.yaml
+    generate_sim_ctrl(npts=npts)
+
+def generate_sim_ctrl(npts):
+    # generate simctrl
+    simctrl = {'analog_probes': {}, 'digital_probes': {}, 'analog_ctrl_inputs': {}}
+    for sig, rng in [
+        ('chan_o', 1.5),
+        ('ctle1_o', 1.5),
+        ('nl1_o', 1.5),
+        ('ctle2_o', 1.5),
+        ('nl2_o', 1.5),
+        ('ctle3_o', 1.5),
+        ('nl3_o', 1.5)
+    ]:
+        for k in range(npts):
+            simctrl['analog_probes'][f'{sig}_{k}'] = {'abspath': f'tb_i.{sig}_{k}', 'range': rng}
+    for sig, path, rng in [
+        ('tx_drv_o', 'tx_drv_o', 1.1),
+        ('dt_rel', 'dt_rel', 1.1),
+        ('dt', 'dt', 62.5e-12)
+    ]:
+        simctrl['analog_probes'][sig] = {'abspath': f'tb_i.{path}', 'range': rng}
+    for sig, path, rng, init in [
+        ('tlo', 'tlo', 62.5e-12, 62.5e-12),
+        ('thi', 'thi', 62.5e-12, 62.5e-12)
+    ]:
+        simctrl['analog_ctrl_inputs'][sig] = {'abspath': f'tb_i.{sig}', 'range': rng, 'init_value': init}
+    for sig, path, width in [
+        ('prbs_o', 'prbs_o', 1),
+        ('clk_en', 'clk_en', 1),
+    ]:
+        simctrl['digital_probes'][sig] = {'abspath': f'tb_i.{path}', 'width': width}
+
+    yaml.dump(simctrl, open(THIS_DIR / 'simctrl.yaml', 'w'))
+
+if __name__ == '__main__':
+    # parse arguments
+    parser = ArgumentParser()
+    parser.add_argument('--target')
+    args = parser.parse_args()
+
+    # run the intended target
+    run_target(target=args.target)

--- a/examples/afe/sim_ctrl.sv
+++ b/examples/afe/sim_ctrl.sv
@@ -14,11 +14,11 @@ module sim_ctrl #(
     `ASSIGN_CONST_REAL(62.5e-12, thi);
 
     initial begin
-        // wait for emulator reset to complete
-        wait_emu_reset();
+        // clamp the maximum emulator timestep
+	set_max_emu_dt(100e-12);	
 
         // wait a certain amount of time
-        sleep_emu(10e-9);
+	#(10us);
 
         // end simulation
         $finish;

--- a/examples/afe/sim_ctrl.sv
+++ b/examples/afe/sim_ctrl.sv
@@ -1,0 +1,26 @@
+`timescale 1s/1ns
+`include "svreal.sv"
+
+module sim_ctrl #(
+    `DECL_REAL(tlo),
+    `DECL_REAL(thi)
+) (
+    `OUTPUT_REAL(tlo),
+    `OUTPUT_REAL(thi)
+);
+    `include "anasymod.sv"
+
+    `ASSIGN_CONST_REAL(62.5e-12, tlo);
+    `ASSIGN_CONST_REAL(62.5e-12, thi);
+
+    initial begin
+        // wait for emulator reset to complete
+        wait_emu_reset();
+
+        // wait a certain amount of time
+        sleep_emu(10e-9);
+
+        // end simulation
+        $finish;
+    end
+endmodule

--- a/examples/afe/sim_ctrl.sv
+++ b/examples/afe/sim_ctrl.sv
@@ -15,7 +15,7 @@ module sim_ctrl #(
 
     initial begin
         // clamp the maximum emulator timestep
-	set_max_emu_dt(100e-12);	
+	set_max_emu_dt(31.25e-12);	
 
         // wait a certain amount of time
 	#(10us);

--- a/examples/afe/source.yaml
+++ b/examples/afe/source.yaml
@@ -1,0 +1,17 @@
+verilog_sources:
+  sim_ctrl:
+    files: "sim_ctrl.sv"
+    fileset: "sim"
+  ams_models:
+    files:
+      - "build/channel/channel.sv"
+      - "build/ctle1/ctle1.sv"
+      - "build/ctle2/ctle2.sv"
+      - "build/ctle3/ctle3.sv"
+      - "build/nonlin/nonlin.sv"
+      - "build/unfm/unfm.sv"
+      - "build/osc/osc.sv"
+defines:
+  DT_MSDSL:
+    name: DT_MSDSL
+    value: 62.5e-12

--- a/examples/afe/tb.sv
+++ b/examples/afe/tb.sv
@@ -118,7 +118,7 @@ module tb;
 
     `MAKE_CONST_REAL(1.0, txp);
     `MAKE_CONST_REAL(-1.0, txn);
-    `MAKE_REAL(tx_drv_o, 1.1);
+    `MAKE_SHORT_REAL(tx_drv_o, 1.1);  // short real used to reduce DSP utilization
     `ITE_INTO_REAL(prbs_o, txp, txn, tx_drv_o);
 
     // channel

--- a/examples/afe/tb.sv
+++ b/examples/afe/tb.sv
@@ -1,0 +1,192 @@
+`timescale 1s/1ns
+
+`include "svreal.sv"
+
+`define MAKE(arg1, arg2, k) `MAKE_REAL(``arg1``_``k``, arg2)
+`define PASS(arg1, arg2, k) `PASS_REAL(``arg1``_``k``, ``arg2``_``k``)
+`define CONNECT(arg1, arg2, k) .``arg1``_``k``(``arg2``_``k``)
+`define NONLIN(arg1, arg2, k) \
+    nonlin #( \
+        `PASS_REAL(in_, ``arg1``_``k``), \
+        `PASS_REAL(out, ``arg2``_``k``) \
+    ) ``nonlin``_``arg1``_``arg2``_``k`` ( \
+        .in_(``arg1``_``k``), \
+        .out(``arg2``_``k``) \
+    )
+
+`define REPLICATE_MACRO_SEMICOLON(name, arg1, arg2) \
+    `name(arg1, arg2, 0); \
+    `name(arg1, arg2, 1); \
+    `name(arg1, arg2, 2); \
+    `name(arg1, arg2, 3)
+
+`define REPLICATE_MACRO_COMMA(name, arg1, arg2) \
+    `name(arg1, arg2, 0), \
+    `name(arg1, arg2, 1), \
+    `name(arg1, arg2, 2), \
+    `name(arg1, arg2, 3)
+
+module tb;
+    // parameters
+    localparam real dtmax = 62.5e-12;
+
+    // uncomment to force a maximum timestep
+    // (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] ext_dt;
+    // assign ext_dt = 25e-12*(1e15);
+
+    // emulator control infrastructure
+    (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] dt_req;
+    (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] emu_dt;
+    (* dont_touch = "true" *) logic emu_clk;
+    (* dont_touch = "true" *) logic emu_rst;
+
+    // PRBS signals
+    logic prbs_o;
+    logic [20:0] sr;
+
+    // oscillator period signals
+    (* dont_touch = "true" *) `MAKE_REAL(tlo, dtmax);
+    (* dont_touch = "true" *) `MAKE_REAL(thi, dtmax);
+    `MAKE_REAL(osc_period, dtmax);
+
+    // oscillator signals
+    logic clk_en;
+
+    // dt scaling signals
+    `MAKE_REAL(dt, dtmax);
+    `MAKE_REAL(dt_rel, 1.1);
+
+    // real-valued in signal chain
+    `REPLICATE_MACRO_SEMICOLON(MAKE, chan_o, 1.5);
+    `REPLICATE_MACRO_SEMICOLON(MAKE, ctle1_o, 1.5);
+    `REPLICATE_MACRO_SEMICOLON(MAKE, nl1_o, 1.5);
+    `REPLICATE_MACRO_SEMICOLON(MAKE, ctle2_o, 1.5);
+    `REPLICATE_MACRO_SEMICOLON(MAKE, nl2_o, 1.5);
+    `REPLICATE_MACRO_SEMICOLON(MAKE, ctle3_o, 1.5);
+    `REPLICATE_MACRO_SEMICOLON(MAKE, nl3_o, 1.5);
+
+    // PRBS (adapted from DaVE)
+    always @(posedge emu_clk) begin
+        if (emu_rst) begin
+            sr <= '1;
+        end else if (clk_en) begin
+            sr[20:1] <= sr[19:0];
+            sr[0] <= sr[20] ^ sr[1];
+        end else begin
+            sr <= sr;
+        end
+    end
+    assign prbs_o = sr[6];
+
+    // Timestep generator
+
+    unfm #(
+        `PASS_REAL(min_val, tlo),
+        `PASS_REAL(max_val, thi),
+        `PASS_REAL(out, osc_period)
+    ) unfm_i (
+        .min_val(tlo),
+        .max_val(thi),
+        .out(osc_period),
+        .emu_clk(emu_clk),
+        .emu_rst(emu_rst)
+    );
+
+    // Oscillator
+
+    osc #(
+        `PASS_REAL(period, osc_period)
+    ) osc_i (
+        .period(osc_period),
+        .dt_req(dt_req),
+        .emu_dt(emu_dt),
+        .clk_en(clk_en),
+        .emu_clk(emu_clk),
+        .emu_rst(emu_rst)
+    );
+
+    // Generate dt and dt_rel signals
+    // TODO: cleanup
+
+    logic signed [16:0] emu_dt_sint;
+    assign emu_dt_sint = emu_rst ? 0 : {1'b0, emu_dt[15:0]};  // 65.535 ps full scale
+    `INT_TO_REAL(emu_dt_sint, 17, emu_dt_real);
+    `MUL_CONST_INTO_REAL((`DT_SCALE), emu_dt_real, dt);
+    `MUL_CONST_INTO_REAL(((`DT_SCALE)/dtmax), emu_dt_real, dt_rel);
+
+    // TX driver
+
+    `MAKE_CONST_REAL(1.0, txp);
+    `MAKE_CONST_REAL(-1.0, txn);
+    `MAKE_REAL(tx_drv_o, 1.1);
+    `ITE_INTO_REAL(prbs_o, txp, txn, tx_drv_o);
+
+    // channel
+
+    channel #(
+        `PASS_REAL(dt, dt),
+        `PASS_REAL(in_, tx_drv_o),
+        `REPLICATE_MACRO_COMMA(PASS, out, chan_o)
+    ) channel_i (
+        .dt(dt),
+        .in_(tx_drv_o),
+        `REPLICATE_MACRO_COMMA(CONNECT, out, chan_o),
+        .emu_clk(emu_clk),
+        .emu_rst(emu_rst)
+    );
+
+    // ctle1
+
+    ctle1 #(
+        `PASS_REAL(dt, dt_rel),
+        `REPLICATE_MACRO_COMMA(PASS, in, chan_o),
+        `REPLICATE_MACRO_COMMA(PASS, out, ctle1_o)
+    ) ctle1_i (
+        .dt(dt_rel),
+        `REPLICATE_MACRO_COMMA(CONNECT, in, chan_o),
+        `REPLICATE_MACRO_COMMA(CONNECT, out, ctle1_o),
+        .emu_clk(emu_clk),
+        .emu_rst(emu_rst)
+    );
+
+    // nonlin
+
+    `REPLICATE_MACRO_SEMICOLON(NONLIN, ctle1_o, nl1_o);
+
+    // ctle2
+
+    ctle2 #(
+        `PASS_REAL(dt, dt_rel),
+        `REPLICATE_MACRO_COMMA(PASS, in, nl1_o),
+        `REPLICATE_MACRO_COMMA(PASS, out, ctle2_o)
+    ) ctle2_i (
+        .dt(dt_rel),
+        `REPLICATE_MACRO_COMMA(CONNECT, in, nl1_o),
+        `REPLICATE_MACRO_COMMA(CONNECT, out, ctle2_o),
+        .emu_clk(emu_clk),
+        .emu_rst(emu_rst)
+    );
+
+    // nonlin2
+
+    `REPLICATE_MACRO_SEMICOLON(NONLIN, ctle2_o, nl2_o);
+
+    // ctle3
+
+    ctle3 #(
+        `PASS_REAL(dt, dt_rel),
+        `REPLICATE_MACRO_COMMA(PASS, in, nl2_o),
+        `REPLICATE_MACRO_COMMA(PASS, out, ctle3_o)
+    ) ctle3_i (
+        .dt(dt_rel),
+        `REPLICATE_MACRO_COMMA(CONNECT, in, nl2_o),
+        `REPLICATE_MACRO_COMMA(CONNECT, out, ctle3_o),
+        .emu_clk(emu_clk),
+        .emu_rst(emu_rst)
+    );
+
+    // nonlin3
+
+    `REPLICATE_MACRO_SEMICOLON(NONLIN, ctle3_o, nl3_o);
+
+endmodule

--- a/examples/afe/tb.sv
+++ b/examples/afe/tb.sv
@@ -28,7 +28,8 @@
 
 module tb;
     // parameters
-    localparam real dtmax = 62.5e-12;
+    localparam real ui = 62.5e-12;
+    localparam real dtmax = 31.25e-12;
 
     // uncomment to force a maximum timestep
     // (* dont_touch = "true" *) logic [((`DT_WIDTH)-1):0] ext_dt;
@@ -45,15 +46,15 @@ module tb;
     logic [20:0] sr;
 
     // oscillator period signals
-    (* dont_touch = "true" *) `MAKE_REAL(tlo, dtmax);
-    (* dont_touch = "true" *) `MAKE_REAL(thi, dtmax);
-    `MAKE_REAL(osc_period, dtmax);
+    (* dont_touch = "true" *) `MAKE_REAL(tlo, ui);
+    (* dont_touch = "true" *) `MAKE_REAL(thi, ui);
+    `MAKE_REAL(osc_period, ui);
 
     // oscillator signals
     logic clk_en;
 
     // dt scaling signals
-    `MAKE_REAL(dt, dtmax);
+    `MAKE_REAL(dt, ui);
     `MAKE_REAL(dt_rel, 1.1);
 
     // real-valued in signal chain

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 
 install_requires=[
     'svreal>=0.2.7',
-    'msdsl>=0.3.6',
+    'msdsl>=0.3.7.dev4',
     'jinja2',
     'pyvcd',
     'pyserial',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.8'
+version = '0.3.9'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 
 install_requires=[
     'svreal>=0.2.7',
-    'msdsl>=0.3.7.dev4',
+    'msdsl>=0.3.7',
     'jinja2',
     'pyvcd',
     'pyserial',


### PR DESCRIPTION
This PR adds a new emulation example: modeling the analog front-end (AFE) of a high-speed link.  It's based on previous efforts like the DragonPHY emulator, but makes use of the new nonlinearity and composition features in **msdsl**.  The changes to the **anasymod** library itself are minimal, since the PR adds just one function to ``anasymod.sv`` (set_max_emu_dt).  As a result, backwards-compatibility issues are not expected.