### PR TITLE
Various new features

### DIFF
--- a/anasymod/analysis.py
+++ b/anasymod/analysis.py
@@ -199,6 +199,8 @@ class Analysis():
                 self.filesets._verilog_headers.append(source)
             elif isinstance(source, VHDLSource):
                 self.filesets._vhdl_sources.append(source)
+            elif isinstance(source, IncludeDir):
+                self.filesets._include_dirs.append(source)
             elif isinstance(source, Define):
                 self.filesets._defines.append(source)
             elif isinstance(source, EDIFFile):

--- a/anasymod/config.py
+++ b/anasymod/config.py
@@ -435,6 +435,10 @@ class Config(BaseConfig):
             to emu_clk.  This can help the design run at higher frequencies, if no time management
             is required. """
 
+        self.treat_v_as_sv = False
+        """ type(bool) : If True, treat Verilog (*.v) files as SystemVerilog (*.sv) in Vivado.
+            This option requires there to be at least one *.v file in the project sources. """
+
 def find_tool(name, hints=None, sys_path_hint=True):
     # set defaults
     if hints is None:

--- a/anasymod/config.py
+++ b/anasymod/config.py
@@ -110,6 +110,8 @@ class EmuConfig:
             return ZCU102()
         elif self.cfg.board_name == BoardNames.ZCU106:
             return ZCU106()
+        elif self.cfg.board_name == BoardNames.ZCU111:
+            return ZCU111()
         elif self.cfg.board_name == BoardNames.ARTY_200T_CUSTOM_LIDAR:
             return ARTY_200T_CUSTOM_LIDAR()
         else:

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -44,9 +44,6 @@ class VivadoEmulation(VivadoTCLGenerator):
         scfg = self.target.str_cfg
         """ type : StructureConfig """
 
-        pcfg = self.target.prj_cfg
-        """ type : EmuConfig """
-
         project_root = self.target.project_root
         # under Windows there is the problem with path length more than 146 characters, that's why we have to use
         # subst command to substitute project directory to a drive letter
@@ -68,7 +65,7 @@ class VivadoEmulation(VivadoTCLGenerator):
         self.add_project_sources(content=self.target.content)
 
         # if desired, treat Verilog (*.v) files as SystemVerilog (*.sv)
-        if pcfg.cfg.treat_v_as_sv:
+        if self.target.prj_cfg.cfg.treat_v_as_sv:
             self.writeln('set_property file_type SystemVerilog [get_files -filter {FILE_TYPE == Verilog}]')
 
         # define the top module

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -206,11 +206,11 @@ class VivadoEmulation(VivadoTCLGenerator):
 
         # run bitstream generation
         err_str = 'The design failed to meet the timing requirements.'
-        ret_error = self.run(filename=r"bitstream.tcl", stack=self.target.prj_cfg.cfg.vivado_stack,
-                             return_error=True, err_str=err_str)
-        if os.name == 'nt':
-            if ret_error:
-                #remove and restore drive substitutions
+        try:
+            self.run(filename=r"bitstream.tcl", stack=self.target.prj_cfg.cfg.vivado_stack, err_str=err_str)
+        except:
+            # remove and restore drive substitutions
+            if os.name == 'nt':
                 if self.subst:
                     try:
                         subprocess.call(f'subst {drive} /d', shell=True)
@@ -221,6 +221,9 @@ class VivadoEmulation(VivadoTCLGenerator):
                             subprocess.call(f'subst {drive} {self.old_subst}', shell=True)
                         except:
                             print(f'WARNING: Mapping of drive:{drive} to network path: {self.old_subst} did not work.')
+
+            # then re-raise the original exception
+            raise
 
 
     def run_FPGA(self, **kwargs):

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -64,15 +64,18 @@ class VivadoEmulation(VivadoTCLGenerator):
         # add all source files to the project (including header files)
         self.add_project_sources(content=self.target.content)
 
-        # if desired, treat Verilog (*.v) files as SystemVerilog (*.sv)
-        if self.target.prj_cfg.cfg.treat_v_as_sv:
-            self.writeln('set_property file_type SystemVerilog [get_files -filter {FILE_TYPE == Verilog}]')
-
         # define the top module
         self.set_property('top', f"{{{self.target.cfg.top_module}}}", '[current_fileset]')
 
         # set define variables
         self.add_project_defines(content=self.target.content, fileset='[current_fileset]')
+
+        # add include directories
+        self.add_include_dirs(content=self.target.content, objects='[current_fileset]')
+
+        # if desired, treat Verilog (*.v) files as SystemVerilog (*.sv)
+        if self.target.prj_cfg.cfg.treat_v_as_sv:
+            self.writeln('set_property file_type SystemVerilog [get_files -filter {FILE_TYPE == Verilog}]')
 
         # specify the level of flattening to use
         self.set_property(

--- a/anasymod/emu/vivado_emu.py
+++ b/anasymod/emu/vivado_emu.py
@@ -205,7 +205,9 @@ class VivadoEmulation(VivadoTCLGenerator):
                 self.writeln('exec subst ' + self.subst + ' ' + self.old_subst)
 
         # run bitstream generation
-        ret_error = self.run(filename=r"bitstream.tcl", stack=self.target.prj_cfg.cfg.vivado_stack, return_error=True)
+        err_str = 'The design failed to meet the timing requirements.'
+        ret_error = self.run(filename=r"bitstream.tcl", stack=self.target.prj_cfg.cfg.vivado_stack,
+                             return_error=True, err_str=err_str)
         if os.name == 'nt':
             if ret_error:
                 #remove and restore drive substitutions

--- a/anasymod/enums.py
+++ b/anasymod/enums.py
@@ -22,6 +22,7 @@ class BoardNames:
     ZC706
     ZCU102
     ZCU106
+    ZCU111
     ULTRA96
     TE0720
 
@@ -33,6 +34,7 @@ class BoardNames:
     ZC706 = 'ZC706'
     ZCU102 = 'ZCU102'
     ZCU106 = 'ZCU106'
+    ZCU111 = 'ZCU111'
     ULTRA96 = 'ULTRA96'
     TE0720 = 'TE0720'
     ARTY_200T_CUSTOM_LIDAR = 'ARTY_200T_CUSTOM_LIDAR'

--- a/anasymod/filesets.py
+++ b/anasymod/filesets.py
@@ -2,7 +2,7 @@ import os, yaml
 from anasymod.sources import (Sources, VerilogSource, VerilogHeader, VHDLSource,
                               SubConfig, XCIFile, XDCFile, MEMFile, BDFile,
                               FunctionalModel, IPRepo, EDIFFile, FirmwareFile,
-                              TCLFile)
+                              TCLFile, IncludeDir)
 from anasymod.defines import Define
 from anasymod.util import expand_searchpaths
 
@@ -23,6 +23,9 @@ class Filesets():
 
         self._vhdl_sources = []
         """:type : List[VHDLSource]"""
+
+        self._include_dirs = []
+        """:type : List[IncludeDir]"""
 
         self._edif_files = []
         """:type : List[EDIFFile]"""
@@ -131,6 +134,13 @@ class Filesets():
                                                      library=cfg['vhdl_sources'][vhdl_source]['library'] if 'library' in cfg['vhdl_sources'][vhdl_source].keys() else None,
                                                      version = cfg['vhdl_sources'][vhdl_source]['version'] if 'version' in cfg['vhdl_sources'][vhdl_source].keys() else None,
                                                      name=vhdl_source))
+        if 'include_dirs' in cfg.keys(): # Add include dirs to filesets
+            print(f'Include Dirs: {[key for key in cfg["include_dirs"].keys()]}')
+            for include_dir in cfg['include_dirs'].keys():
+                self._include_dirs.append(IncludeDir(files=cfg['include_dirs'][include_dir]['files'],
+                                                     fileset=cfg['include_dirs'][include_dir].get('fileset', 'default'),
+                                                     config_path=cfg_path,
+                                                     name=include_dir))
         if 'edif_files' in cfg.keys(): # Add EDIF files to filesets
             print(f'EDIF Files: {[key for key in cfg["edif_files"].keys()]}')
             for edif_file in cfg['edif_files'].keys():
@@ -241,6 +251,9 @@ class Filesets():
         # Read in vhdlsource objects to fileset dict
         self._add_to_fileset_dict(name='vhdl_sources', container=self._expand_source_paths(self._vhdl_sources))
 
+        # Read in include_dirs objects to fileset dict
+        self._add_to_fileset_dict(name='include_dirs', container=self._expand_source_paths(self._include_dirs))
+
         # Read in edif_files objects to fileset dict
         self._add_to_fileset_dict(name='edif_files', container=self._expand_source_paths(self._edif_files))
 
@@ -297,6 +310,9 @@ class Filesets():
 
     def add_define(self, define: Define):
         self._defines.append(define)
+
+    def add_include_dir(self, include_dir: IncludeDir):
+        self._include_dirs.append(include_dir)
 
     def add_edif_file(self, edif_file: EDIFFile):
         self._edif_files.append(edif_file)

--- a/anasymod/filesets.py
+++ b/anasymod/filesets.py
@@ -165,7 +165,8 @@ class Filesets():
                 self._xdc_files.append(XDCFile(files=cfg['xdc_files'][xdc_file]['files'],
                                                fileset=cfg['xdc_files'][xdc_file]['fileset'] if 'fileset' in cfg['xdc_files'][xdc_file].keys() else 'default',
                                                config_path=cfg_path,
-                                               name=xdc_file))
+                                               name=xdc_file,
+                                               xdc_mode=cfg['xdc_files'][xdc_file].get('xdc_mode', None)))
         if 'mem_files' in cfg.keys():  # Add mem files to filesets
             print(f'Mem Files: {[key for key in cfg["mem_files"].keys()]}')
             for mem_file in cfg['mem_files'].keys():

--- a/anasymod/fpga_boards/boards.py
+++ b/anasymod/fpga_boards/boards.py
@@ -160,3 +160,21 @@ class ZCU106(FPGA_Board):
     uart_zynq_pid = [60017]
     uart_suffix = '.0'  # needed since this board has four com ports under the same VID/PID
     is_ultrascale = True
+
+class ZCU111(FPGA_Board):
+    """
+    Container to store ZCU111 FPGA board specific properties.
+    """
+    clk_pin = ['AL17', 'AM17']  # from Table 3-17 in the user guide
+    clk_io = 'LVDS'
+    clk_freq = 125e6
+    board_part = 'xilinx.com:zcu111:part0:1.2'
+    full_part_name = 'xczu28dr-ffvg1517-2-e'
+    short_part_name = 'xczu28'
+    bram = 38e6
+    fpga_sim_ctrl = [FPGASimCtrl.UART_ZYNQ, FPGASimCtrl.VIVADO_VIO]
+    uart_zynq_vid = [1027]  # FT4232HL from Table 3-8 in the user guide
+    uart_zynq_pid = [24593]  # FT4232HL from Table 3-8 in the user guide
+    uart_suffix = '.1'  # needed since this board has four com ports under the same VID/PID
+    is_ultrascale = True
+    no_rev_check = True  # needed in case the FPGA is an engineering sample

--- a/anasymod/generators/vivado.py
+++ b/anasymod/generators/vivado.py
@@ -154,6 +154,24 @@ class VivadoTCLGenerator(CodeGenerator):
         cmd.append('{ '+' '.join('"'+back2fwd(file)+'"' for file in files)+' }')
         self.writeln(' '.join(cmd))
 
+    def add_include_dirs(self, content, objects):
+        # do nothing if there are no include directories
+        if len(content.include_dirs) == 0:
+            return
+
+        # otherwise, generate list of all include directories
+        inc_dirs = []
+        for include_dir in content.include_dirs:
+            inc_dirs += include_dir.files
+
+        # format into a TCL argument
+        inc_dirs = ['"' + str(inc_dir) + '"' for inc_dir in inc_dirs]  # add quotes
+        inc_dirs = ' '.join(inc_dirs)  # separate by spaces
+        inc_dirs = '{ ' + inc_dirs + ' }'  # surround with curly braces
+
+        # then set the include_dirs property
+        self.set_property(name='include_dirs', value=inc_dirs, objects=objects)
+
     def set_property(self, name, value, objects):
         self.writeln(' '.join(['set_property', '-name', name, '-value', value, '-objects', objects]))
 

--- a/anasymod/generators/vivado.py
+++ b/anasymod/generators/vivado.py
@@ -221,11 +221,7 @@ class VivadoTCLGenerator(CodeGenerator):
             cmd.append('-nojournal')
 
         # run the script
-        ret_error = call(args=cmd, cwd=self.target.prj_cfg.build_root, err_str=err_str)
-        if return_error:
-            return ret_error
-        else:
-            return 0
+        return call(args=cmd, cwd=self.target.prj_cfg.build_root, err_str=err_str, return_error=return_error)
 
     @property
     def version_year(self):

--- a/anasymod/generators/vivado.py
+++ b/anasymod/generators/vivado.py
@@ -155,16 +155,17 @@ class VivadoTCLGenerator(CodeGenerator):
         self.writeln(' '.join(cmd))
 
     def add_include_dirs(self, content, objects):
-        # do nothing if there are no include directories
-        if len(content.include_dirs) == 0:
-            return
-
         # otherwise, generate list of all include directories
         inc_dirs = []
         for include_dir in content.include_dirs:
             inc_dirs += include_dir.files
 
+        # do nothing if there are no include directories
+        if len(inc_dirs) == 0:
+            return
+
         # format into a TCL argument
+        inc_dirs = [back2fwd(inc_dir) for inc_dir in inc_dirs]  # fix backslashes
         inc_dirs = ['"' + str(inc_dir) + '"' for inc_dir in inc_dirs]  # add quotes
         inc_dirs = ' '.join(inc_dirs)  # separate by spaces
         inc_dirs = '{ ' + inc_dirs + ' }'  # surround with curly braces

--- a/anasymod/sim/icarus.py
+++ b/anasymod/sim/icarus.py
@@ -24,9 +24,14 @@ class IcarusSimulator(Simulator):
 
         # add include directories, remove filename from paths and create a list of inc dirs removing duplicates
         inc_dirs = set()
+
         for sources in self.target.content.verilog_headers:
             for src in sources.files:
                 inc_dirs.add(os.path.dirname(src))
+
+        for sources in self.target.content.include_dirs:
+            for src in sources.files:
+                inc_dirs.add(src)
 
         for inc_dir in inc_dirs:
             cmd.extend(['-I', inc_dir])

--- a/anasymod/sim/vivado.py
+++ b/anasymod/sim/vivado.py
@@ -15,6 +15,10 @@ class VivadoSimulator(Simulator):
         # add all source files to the project (including header files)
         v.add_project_sources(content=self.target.content)
 
+        # if desired, treat Verilog (*.v) files as SystemVerilog (*.sv)
+        if self.target.prj_cfg.cfg.treat_v_as_sv:
+            v.writeln('set_property file_type SystemVerilog [get_files -filter {FILE_TYPE == Verilog}]')
+
         # define the top module
         v.set_property('top', f"{{{self.target.cfg.top_module}}}", '[get_filesets {sim_1 sources_1}]')
 

--- a/anasymod/sim/vivado.py
+++ b/anasymod/sim/vivado.py
@@ -15,15 +15,18 @@ class VivadoSimulator(Simulator):
         # add all source files to the project (including header files)
         v.add_project_sources(content=self.target.content)
 
-        # if desired, treat Verilog (*.v) files as SystemVerilog (*.sv)
-        if self.target.prj_cfg.cfg.treat_v_as_sv:
-            v.writeln('set_property file_type SystemVerilog [get_files -filter {FILE_TYPE == Verilog}]')
-
         # define the top module
         v.set_property('top', f"{{{self.target.cfg.top_module}}}", '[get_filesets {sim_1 sources_1}]')
 
         # set define variables
         v.add_project_defines(content=self.target.content, fileset='[get_filesets {sim_1 sources_1}]')
+
+        # add include directories
+        v.add_include_dirs(content=self.target.content, objects='[get_filesets {sim_1 sources_1}]')
+
+        # if desired, treat Verilog (*.v) files as SystemVerilog (*.sv)
+        if self.target.prj_cfg.cfg.treat_v_as_sv:
+            v.writeln('set_property file_type SystemVerilog [get_files -filter {FILE_TYPE == Verilog}]')
 
         # launch the simulation
         v.set_property('{xsim.simulate.runtime}', '{-all}', '[get_fileset sim_1]')

--- a/anasymod/sim/xcelium.py
+++ b/anasymod/sim/xcelium.py
@@ -62,9 +62,14 @@ class XceliumSimulator(Simulator):
 
         # add include directories, remove filename from paths and create a list of inc dirs removing duplicates
         inc_dirs = set()
+
         for sources in self.target.content.verilog_headers:
             for src in sources.files:
                 inc_dirs.add(os.path.dirname(src))
+
+        for sources in self.target.content.include_dirs:
+            for src in sources.files:
+                inc_dirs.add(src)
 
         for inc_dir in inc_dirs:
             cmd.extend(['-incdir', inc_dir])

--- a/anasymod/sources.py
+++ b/anasymod/sources.py
@@ -88,6 +88,10 @@ class VHDLSource(Sources):
     def generate(self):
         self.dump()
 
+class IncludeDir(Sources):
+    def __init__(self, files: Union[list, str], name, fileset=r"default", config_path=None):
+        super().__init__(files=files, fileset=fileset, config_path=config_path, name=name)
+
 class EDIFFile(Sources):
     def __init__(self, files: Union[list, str], name, fileset=r"default", config_path=None):
         super().__init__(files=files, fileset=fileset, config_path=config_path, name=name)

--- a/anasymod/sources.py
+++ b/anasymod/sources.py
@@ -105,7 +105,15 @@ class TCLFile(Sources):
         super().__init__(files=files, fileset=fileset, config_path=config_path, name=name)
 
 class XDCFile(Sources):
-    def __init__(self, files: Union[list, str], name, fileset=r"default", config_path=None):
+    def __init__(self, files: Union[list, str], name, fileset=r"default", config_path=None, xdc_mode=None):
+        # set defaults
+        if xdc_mode is None:
+            xdc_mode = 'read_xdc'
+
+        # save custom settings
+        self.xdc_mode = xdc_mode
+
+        # call the super constructor
         super().__init__(files=files, fileset=fileset, config_path=config_path, name=name)
 
 class MEMFile(Sources):

--- a/anasymod/targets.py
+++ b/anasymod/targets.py
@@ -279,6 +279,8 @@ class Content():
         """:type : List[VerilogHeader]"""
         self.vhdl_sources = []
         """:type : List[VHDLSource]"""
+        self.include_dirs = []
+        """:type : List[IncludeDir]"""
         self.defines = []
         """:type : List[Define]"""
         self.edif_files = []

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.4.0.dev1'
+version = '0.4.0.dev2'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.4.0.dev4'
+version = '0.4.0.dev5'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.3.9'
+version = '0.4.0.dev1'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.4.0.dev6'
+version = '0.4.0'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.4.0.dev5'
+version = '0.4.0.dev6'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.4.0.dev2'
+version = '0.4.0.dev3'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'anasymod'
-version = '0.4.0.dev3'
+version = '0.4.0.dev4'
 
 DESCRIPTION = '''\
 Tool for running mixed-signal emulations on FPGAs\


### PR DESCRIPTION
This PR adds a couple of small new features:
* Adds ``include_dirs`` category that can be used in ``source.yaml``.  This sets the search path for `` `include `` directives.  It's useful because some RTL sources contain `` `include `` directives that have relative paths.
* Adds support for a new board, ``ZCU111``.
* Adds a new boolean option in ``prj.yaml`` called ``treat_v_as_sv`` (under ``PROJECT``).  This option defaults to ``false``, but when ``true``, it causes Vivado to consider ``.v`` files as having SystemVerilog syntax, rather than Verilog syntax.  This is useful because many other tools do not differentiate between ``.v`` and ``.sv`` extensions, so users may not realize that they have included SystemVerilog syntax in a ``.v`` file.  Rather then requiring them to change the extension, this option makes the tool assume that all Verilog files have SystemVerilog syntax.
* Adds a new option for entries in ``xdc_files`` in ``source.yaml`` called ``xdc_mode``.  Options are ``read_xdc`` (default), ``pre_constrs``, and ``post_constrs``.
    * ``read_xdc``: use the ``read_xdc`` command to read the provided XDC file(s).  This was the behavior prior to adding the ``xdc_mode`` feature (and is still the default, for backwards compatibility).
    * ``pre_constr``: prepend the contents of the provided XDC file(s) to the generated constraints file.
    * ``post_constr``: append the contents of the provided XDC file(s) to the generated constraints file.  This is useful because it allows the user to add constraints on generated clock signals (``clk_other_0``, ``clk_other_1``, etc.)
* Raises an exception if the design doesn't meet timing.  Previously, the user had to review the log or open the design to make sure timing is met.